### PR TITLE
Better integration with Galaxy's run.sh

### DIFF
--- a/gravity/commands/cmd_start.py
+++ b/gravity/commands/cmd_start.py
@@ -1,8 +1,10 @@
+import sys
+
 import click
 
-from gravity import options
+from gravity import config_manager, options
 from gravity import process_manager
-from gravity.io import info
+from gravity.io import info, error
 
 
 @click.command("start")
@@ -11,6 +13,14 @@ from gravity.io import info
 @click.pass_context
 def cli(ctx, foreground, instance):
     """Start configured services."""
+    if not instance:
+        with config_manager.config_manager(state_dir=ctx.parent.state_dir) as cm:
+            # If there are no configs registered, we will attempt to auto-register one
+            cm.auto_register()
+        if not cm.instance_count:
+            error("Nothing to start: no Galaxy instances configured and no Galaxy configuration files cound be found, "
+                  "see `galaxyctl register --help`")
+            sys.exit(1)
     with process_manager.process_manager(state_dir=ctx.parent.state_dir, foreground=foreground) as pm:
         pm.start(instance)
         if foreground:

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -48,19 +48,14 @@ class BaseProcessManager(object, metaclass=ABCMeta):
 
     @abstractmethod
     def start(self, instance_names):
-        """If start is called from the root of a Galaxy source directory with
-        no args, automatically add this instance.
-        """
-        if not instance_names and self.config_manager.instance_count == 0:
-            configs = (os.path.join("config", "galaxy.yml"), os.path.join("config", "galaxy.yml.sample"))
-            for config in configs:
-                if os.path.exists(config):
-                    if not self.config_manager.is_registered(os.path.abspath(config)):
-                        self.config_manager.add([config])
-                    break
+        """ """
 
     @abstractmethod
     def _process_config_changes(self, configs, meta_changes):
+        """ """
+
+    @abstractmethod
+    def terminate(self):
         """ """
 
     @abstractmethod

--- a/gravity/process_manager/supervisor_manager.py
+++ b/gravity/process_manager/supervisor_manager.py
@@ -368,7 +368,6 @@ class SupervisorProcessManager(BaseProcessManager):
                     self.supervisorctl("restart", program_name)
 
     def start(self, instance_names):
-        super(SupervisorProcessManager, self).start(instance_names)
         self.__start_stop("start", instance_names)
         self.supervisorctl("status")
 


### PR DESCRIPTION
- Use `$GALAXY_ROOT_DIR` and `$GALAXY_CONFIG_FILE`
- Refactor auto-registration on `galaxy`/`galaxyctl start`
- Fail to start with a useful error if no configs are registered