### PR TITLE
Fix for the case where a job_conf.xml exists but no handlers are defined

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -147,7 +147,7 @@ class ConfigManager(object):
         # FIXME: use galaxy job conf parsing I guess, if it's not a mess of slow loading deps
         rval = []
         root = elementtree.parse(conf).getroot()
-        for handler in root.find("handlers"):
+        for handler in (root.find("handlers") or []):
             rval.append({"service_name": handler.attrib["id"]})
         return rval
 


### PR DESCRIPTION
@dannon immediately ran into this after the merge of the Gravity PR to Galaxy. I guess we will have to release a 0.9.1 version and PR that to Galaxy... Hopefully there aren't a ton of these. I guess the Galaxy startup tests don't exactly cover a ton of cases.