### PR TITLE
Do not raise error if config file section is empty

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -81,11 +81,11 @@ class ConfigManager(object):
         if defaults is not None:
             app_config.update(defaults)
 
-        _app_config = config_dict.get(server_section)
-        if not _app_config:
+        if server_section not in config_dict:
             error(f"Config file {conf} does not look like valid Galaxy, Reports or Tool Shed configuration file")
             return None
 
+        _app_config = config_dict.get(server_section) or {}
         app_config.update(_app_config)
 
         # This is the core that needs to be implemented


### PR DESCRIPTION
Fix for starting Galaxy with the sample config file which can have
all options commented out, which presently errors with:

```
Config file /srv/galaxy/config/galaxy.yml.sample does not look like valid Galaxy, Reports or Tool Shed configuration file
```

See e.g.:

https://github.com/galaxyproject/galaxy/runs/5019325678?check_suite_focus=true#step:11:1662