### PR TITLE
Automatically switch to non-sample galaxy.yml if it exists

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -11,6 +11,9 @@ import yaml
 from gravity.util import AttributeDict
 
 
+GALAXY_YML_SAMPLE_PATH = "lib/galaxy/config/sample/galaxy.yml.sample"
+
+
 class GracefulMethod(enum.Enum):
     DEFAULT = 0
     SIGHUP = 1
@@ -144,6 +147,11 @@ class GravityState(AttributeDict):
             for config_file, config_dict in self[key].items():
                 # resolve path, so we always deal with absolute and symlink-resolved paths
                 config_file = os.path.realpath(config_file)
+                if config_file.endswith(GALAXY_YML_SAMPLE_PATH):
+                    root_dir = config_dict['attribs']['galaxy_root']
+                    non_sample_path = os.path.join(root_dir, 'config', 'galaxy.yml')
+                    if os.path.exists(non_sample_path):
+                        config_file = non_sample_path
                 normalized_state[key][config_file] = ConfigFile(config_dict)
         self.update(normalized_state)
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -79,3 +79,12 @@ def test_auto_register(galaxy_yml, default_config_manager, monkeypatch):
     assert not default_config_manager.is_registered(str(galaxy_yml))
     default_config_manager.auto_register()
     assert default_config_manager.is_registered(str(galaxy_yml))
+
+
+def test_register_sample_update_to_non_sample(galaxy_root_dir, state_dir, default_config_manager):
+    galaxy_yml_sample = galaxy_root_dir / "config" / "galaxy.yml.sample"
+    default_config_manager.add([str(galaxy_yml_sample)])
+    galaxy_yml = galaxy_root_dir / "config" / "galaxy.yml"
+    galaxy_yml_sample.copy(galaxy_yml)
+    default_config_manager.instance_count == 1
+    assert default_config_manager.get_registered_config(str(galaxy_yml))


### PR DESCRIPTION
Should fix the issue @dannon ran into with Galaxy continuing to start up from galaxy.yml.sample