### PR TITLE
Fix typo in ``log_dir`` description

### DIFF
--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -132,7 +132,7 @@ Gravity will attempt to find the root directory, but you can set the directory e
         None,
         description="""
 Set to a directory that should contain log files for the processes controlled by Gravity.
-If not specified defaults to ``<state_dir>/logs``.
+If not specified defaults to ``<state_dir>/log``.
 """)
     virtualenv: Optional[str] = Field(None, description="""
 Set to Galaxy's virtualenv directory.


### PR DESCRIPTION
The default is `log` not `logs`, see https://github.com/galaxyproject/gravity/blob/f4c73ae92a4301b4c4967494bfe413f0e22d14c3/gravity/config_manager.py#L80