### PR TITLE
Shortcut individual services fix

### DIFF
--- a/gravity/commands/cmd_follow.py
+++ b/gravity/commands/cmd_follow.py
@@ -8,6 +8,11 @@ from gravity import process_manager
 @options.required_instance_arg()
 @click.pass_context
 def cli(ctx, instance):
-    """Follow log files of configured instances."""
+    """Follow log files of configured instances.
+
+    If INSTANCE matches an instance name, logs of all services configured for the instance are followed.
+
+    If INSTANCE does not match an instance name, it is assumed to be a service and only logs of the listed service(s)
+    are followed."""
     with process_manager.process_manager(state_dir=ctx.parent.state_dir, start_daemon=False) as pm:
         pm.follow(instance)

--- a/gravity/commands/cmd_graceful.py
+++ b/gravity/commands/cmd_graceful.py
@@ -8,6 +8,11 @@ from gravity import process_manager
 @options.required_instance_arg()
 @click.pass_context
 def cli(ctx, instance):
-    """Gracefully reload configured services."""
+    """Gracefully reload configured services.
+
+    If INSTANCE matches an instance name, all services configured for the instance are restarted.
+
+    If INSTANCE does not match an instance name, it is assumed to be a service and only the listed service(s) are
+    restarted."""
     with process_manager.process_manager(state_dir=ctx.parent.state_dir) as pm:
         pm.graceful(instance)

--- a/gravity/commands/cmd_restart.py
+++ b/gravity/commands/cmd_restart.py
@@ -8,6 +8,11 @@ from gravity import process_manager
 @options.required_instance_arg()
 @click.pass_context
 def cli(ctx, instance):
-    """Restart configured services."""
+    """Restart configured services.
+
+    If INSTANCE matches an instance name, all services configured for the instance are restarted.
+
+    If INSTANCE does not match an instance name, it is assumed to be a service and only the listed service(s) are
+    restarted."""
     with process_manager.process_manager(state_dir=ctx.parent.state_dir) as pm:
         pm.restart(instance)

--- a/gravity/commands/cmd_start.py
+++ b/gravity/commands/cmd_start.py
@@ -24,7 +24,7 @@ def cli(ctx, foreground, instance, quiet=False):
         pm.start(instance)
         if foreground:
             pm.follow(instance, quiet=quiet)
-        elif pm.config_manager.single_instance == 1:
+        elif pm.config_manager.single_instance:
             config = list(pm.config_manager.get_registered_configs().values())[0]
             info(f"Log files are in {config.attribs['log_dir']}")
         else:

--- a/gravity/commands/cmd_start.py
+++ b/gravity/commands/cmd_start.py
@@ -11,7 +11,12 @@ from gravity.io import info, exception
 @options.no_log_option()
 @click.pass_context
 def cli(ctx, foreground, instance, quiet=False):
-    """Start configured services."""
+    """Start configured services.
+
+    If INSTANCE matches an instance name, all services configured for the instance are started.
+
+    If INSTANCE does not match an instance name, it is assumed to be a service and only the listed service(s) are
+    started."""
     if not instance:
         with config_manager.config_manager(state_dir=ctx.parent.state_dir) as cm:
             # If there are no configs registered, we will attempt to auto-register one

--- a/gravity/commands/cmd_stop.py
+++ b/gravity/commands/cmd_stop.py
@@ -8,6 +8,11 @@ from gravity import process_manager
 @options.required_instance_arg()
 @click.pass_context
 def cli(ctx, instance):
-    """Stop configured services."""
+    """Stop configured services.
+
+    If INSTANCE matches an instance name, all services configured for the instance are stopped.
+
+    If INSTANCE does not match an instance name, it is assumed to be a service and only the listed service(s) are
+    stopped."""
     with process_manager.process_manager(state_dir=ctx.parent.state_dir, start_daemon=False) as pm:
         pm.stop(instance)

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -74,7 +74,7 @@ class BaseProcessManager(object, metaclass=ABCMeta):
         # ...` can be used if desired, though
         if not self.tail:
             exception("`tail` not found on $PATH, please install it")
-        instance_names, service_names = self.get_instance_names(instance_names)
+        instance_names, service_names, registered_instance_names = self.get_instance_names(instance_names)
         log_files = []
         if quiet:
             cmd = [self.tail, "-f", self.log_file]
@@ -82,7 +82,7 @@ class BaseProcessManager(object, metaclass=ABCMeta):
             tail_popen.wait()
         else:
             if not instance_names:
-                instance_names = self.get_instance_names([])[0]
+                instance_names = registered_instance_names
             for instance_name in instance_names:
                 config = self.config_manager.get_instance_config(instance_name)
                 log_dir = config["attribs"]["log_dir"]
@@ -124,4 +124,4 @@ class BaseProcessManager(object, metaclass=ABCMeta):
             instance_names = registered_instance_names
         else:
             exception("No instances registered (hint: `galaxyctl register /path/to/galaxy.yml`)")
-        return instance_names, unknown_instance_names
+        return instance_names, unknown_instance_names, registered_instance_names

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -109,9 +109,13 @@ class BaseProcessManager(object, metaclass=ABCMeta):
         registered_instance_names = self.config_manager.get_registered_instances()
         unknown_instance_names = []
         if instance_names:
+            _instance_names = []
             for n in instance_names:
-                if n not in registered_instance_names:
+                if n in registered_instance_names:
+                    _instance_names.append(n)
+                else:
                     unknown_instance_names.append(n)
+            instance_names = _instance_names
         elif registered_instance_names:
             instance_names = registered_instance_names
         else:


### PR DESCRIPTION
Technically the control subcommands (`start`, `stop`, `restart`, etc.) take a list of instances as arguments, but we do a lot of shortcutting if there is only one instance registered, which is the common case.  In this case, if the instance arg is actually a service for that instance, we perform the desired operation just for that service. e.g.

```console
$ galaxyctl restart gunicorn
```

is a shortcut for:

```console
$ galaxyctl supervisorctl restart gunicorn
```

Except it didn't work due to a bug,  which this PR fixes.

Draft for a moment because I realized I should make the help explain that.