### PR TITLE
Only default to preload = true for gunicorn if not using unicornherder

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -117,6 +117,8 @@ class ConfigManager(object):
                 exception(f"Cannot locate Galaxy root directory: set $GALAXY_ROOT_DIR or `root' in the `galaxy' section of {conf}")
 
         if gravity_config.gunicorn.enable:
+            if config.attribs["gunicorn"]["preload"] is None:
+                config.attribs["gunicorn"]["preload"] = config.attribs["app_server"] != "unicornherder"
             config.services.append(service_for_service_type(config.attribs["app_server"])(config_type=config.config_type))
         if gravity_config.celery.enable:
             config.services.append(service_for_service_type("celery")(config_type=config.config_type))

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -92,11 +92,11 @@ Value is a positive number or 0. Setting it to 0 has the effect of infinite time
 If you disable the ``preload`` option workers need to have finished booting within the timeout.
 """)
     extra_args: str = Field(default="", description="Extra arguments to pass to Gunicorn command line.")
-    preload: bool = Field(
-        default=True,
+    preload: Optional[bool] = Field(
+        default=None,
         description="""
 Use Gunicorn's --preload option to fork workers after loading the Galaxy Application.
-Consumes less memory when multiple processes are configured.
+Consumes less memory when multiple processes are configured. Default is ``false`` if using unicornherder, else ``true``.
 """)
 
 


### PR DESCRIPTION
When `--preload` is used with `-D` (daemon), the pid file is not written until the application is fully loaded, but the process still detaches from its parent relatively early. [Because unicornherder only waits ~5 seconds](https://github.com/alphagov/unicornherder/blob/a89e01278490ad73a4ede89eb2acc57b19269601/unicornherder/herder.py#L220) for the pid file to exist, unicornherder exits with a failure (and leaves behind a running, unmanaged gunicorn).

A quick test I ran, `alive` is when the pid file was written:

```console
(venv) [g2test@galaxy07 ~]$ ./gunicorn-test.sh preload
started 1654531064
detached 1654531067 (+3s since started)
alive 1654531147 (+83s since started, +80s since detached)
(venv) [g2test@galaxy07 ~]$ ./gunicorn-test.sh kill
waiting for unlink: /tmp/gunicorn.pid....
(venv) [g2test@galaxy07 ~]$ ./gunicorn-test.sh no-preload
started 1654531203
detached 1654531206 (+3s since started)
alive 1654531207 (+4s since started, +1s since detached)
(venv) [g2test@galaxy07 ~]$ 
```