### PR TITLE
Add option to specify tusd path

### DIFF
--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -46,6 +46,7 @@ class TusdSettings(BaseModel):
 Enable tusd server.
 If enabled, you also need to set up your proxy as outlined in https://docs.galaxyproject.org/en/latest/admin/nginx.html#receiving-files-via-the-tus-protocol.
 """)
+    tusd_path: str = Field(default="tusd", description="""Path to tusd binary""")
     host: str = Field("localhost", description="Host to bind the tusd server to")
     port: int = Field(1080, description="Port to bind the tusd server to")
     upload_dir: str = Field(description="""

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -103,7 +103,7 @@ class GalaxyGxItProxyService(Service):
 class GalaxyTUSDService(Service):
     service_type = "tusd"
     service_name = "tusd"
-    command_template = "tusd -host={tusd[host]} -port={tusd[port]} -upload-dir={tusd[upload_dir]}" \
+    command_template = "{tusd[tusd_path]} -host={tusd[host]} -port={tusd[port]} -upload-dir={tusd[upload_dir]}" \
                        " -hooks-http={galaxy_infrastructure_url}/api/upload/hooks" \
                        " -hooks-http-forward-headers=X-Api-Key,Cookie {tusd[extra_args]}"
 


### PR DESCRIPTION
Shouldn't be necessary for the others since everything else would typically be installed in the venv. `tusd` could be as well if you choose.