### PR TITLE
Support setting per-service environment variables

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -207,10 +207,10 @@ class ConfigManager(object):
         if isinstance(conf, dict):
             handling = conf.get('handling') or {}
             processes = handling.get('processes') or []
-            for handler in processes:
+            for handler_name, handler_options in processes.items():
                 rval.append({
-                    "service_name": handler,
-                    "environment": processes[handler].get("environment", None)
+                    "service_name": handler_name,
+                    "environment": (handler_options or {}).get("environment", None)
                 })
         return rval
 

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -208,7 +208,10 @@ class ConfigManager(object):
             handling = conf.get('handling') or {}
             processes = handling.get('processes') or []
             for handler in processes:
-                rval.append({"service_name": handler})
+                rval.append({
+                    "service_name": handler,
+                    "environment": processes[handler].get("environment", None)
+                })
         return rval
 
     def _register_config_file(self, key, val):

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -45,6 +45,14 @@ class BaseProcessManager(object, metaclass=ABCMeta):
     def _service_program_name(self, instance_name, service):
         return f"{instance_name}_{service['config_type']}_{service['service_type']}_{service['service_name']}"
 
+    def _service_environment(self, service, attribs):
+        environment = service.get_environment()
+        environment_from = service.environment_from
+        if not environment_from:
+            environment_from = service.service_type
+        environment.update(attribs.get(environment_from, {}).get("environment", {}))
+        return environment
+
     @abstractmethod
     def start(self, instance_names):
         """ """

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -53,6 +53,12 @@ Directory to store uploads in.
 Must match ``tus_upload_store`` setting in ``galaxy:`` section.
 """)
     extra_args: str = Field(default="", description="Extra arguments to pass to tusd command line.")
+    environment: Dict[str, str] = Field(
+        default=[],
+        description="""
+Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+names.
+""")
 
 
 class CelerySettings(BaseModel):
@@ -63,6 +69,12 @@ class CelerySettings(BaseModel):
     queues: str = Field("celery,galaxy.internal,galaxy.external", description="Queues to join")
     pool: Pool = Field(Pool.threads, description="Pool implementation")
     extra_args: str = Field(default="", description="Extra arguments to pass to Celery command line.")
+    environment: Dict[str, str] = Field(
+        default=[],
+        description="""
+Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+names.
+""")
 
     class Config:
         use_enum_values = True
@@ -98,6 +110,12 @@ If you disable the ``preload`` option workers need to have finished booting with
 Use Gunicorn's --preload option to fork workers after loading the Galaxy Application.
 Consumes less memory when multiple processes are configured.
 """)
+    environment: Dict[str, str] = Field(
+        default=[],
+        description="""
+Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+names.
+""")
 
 
 class GxItProxySettings(BaseModel):
@@ -127,6 +145,12 @@ This is an advanced option that is only needed when proxying to remote interacti
         description="""
 Rewrite location blocks with proxy port.
 This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
+""")
+    environment: Dict[str, str] = Field(
+        default=[],
+        description="""
+Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+names.
 """)
 
 


### PR DESCRIPTION
This allows you to set environment variables on a per-service basis using the `environment` key of a setting, e.g.:

```yaml
gravity:
  gunicorn:
    environment:
      # set a var
      FOO: bar
      # override the default PYTHONPATH=lib
      PYTHONPATH: lib:/path/to/dynamic/rules
```

Unfortunately, you cannot *unset* a var because they get saved in the configstate, but updating the value of a set var does update its value in the supervisor config.