### PR TITLE
Don't catch exceptions in the deregister, register, and rename subcommands

### DIFF
--- a/gravity/commands/cmd_deregister.py
+++ b/gravity/commands/cmd_deregister.py
@@ -2,7 +2,6 @@ import click
 
 from gravity import config_manager
 from gravity import options
-from gravity.io import exception
 
 
 @click.command("deregister")
@@ -14,7 +13,4 @@ def cli(ctx, config):
     aliases: remove, forget
     """
     with config_manager.config_manager(state_dir=ctx.parent.state_dir) as cm:
-        try:
-            cm.remove(config)
-        except Exception as exc:
-            exception("Caught exception: %s", exc)
+        cm.remove(config)

--- a/gravity/commands/cmd_register.py
+++ b/gravity/commands/cmd_register.py
@@ -2,7 +2,6 @@ import click
 
 from gravity import config_manager
 from gravity import options
-from gravity.io import exception
 
 
 @click.command("register")
@@ -14,7 +13,4 @@ def cli(ctx, config):
     aliases: add
     """
     with config_manager.config_manager(state_dir=ctx.parent.state_dir) as cm:
-        try:
-            cm.add(config)
-        except Exception as exc:
-            exception("Caught exception: %s", exc)
+        cm.add(config)

--- a/gravity/commands/cmd_rename.py
+++ b/gravity/commands/cmd_rename.py
@@ -2,7 +2,6 @@ import click
 
 from gravity import config_manager
 from gravity import options
-from gravity.io import error
 
 
 @click.command("reregister")
@@ -15,7 +14,4 @@ def cli(ctx, old_config, new_config):
     aliases: rename
     """
     with config_manager.config_manager(state_dir=ctx.parent.state_dir) as cm:
-        try:
-            cm.rename(old_config, new_config)
-        except Exception as exc:
-            error("Caught exception: %s", exc)
+        cm.rename(old_config, new_config)


### PR DESCRIPTION
Doing so loses the traceback, making it a lot harder to debug. Also, `gravity.io.exception()` doesn't take any args beyond the message string.