### PR TITLE
`processes` in the `handling` dict in the job conf dict is a dict, not a list

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -208,7 +208,7 @@ class ConfigManager(object):
                 exception(f"Unknown job config file type: {conf}")
         if isinstance(conf, dict):
             handling = conf.get('handling') or {}
-            processes = handling.get('processes') or []
+            processes = handling.get('processes') or {}
             for handler_name, handler_options in processes.items():
                 rval.append({
                     "service_name": handler_name,


### PR DESCRIPTION
Should fix the test error in galaxyproject/galaxy#13995:

```pytb
Traceback (most recent call last):
1056
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gravity/commands/cmd_register.py", line 18, in cli
1057
    cm.add(config)
1058
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gravity/config_manager.py", line 418, in add
1059
    conf = self.get_config(config_file, defaults=defaults)
1060
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gravity/config_manager.py", line 143, in get_config
1061
    for service_name in [x["service_name"] for x in ConfigManager.get_job_config(job_config) if x["service_name"] not in webapp_service_names]:
1062
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gravity/config_manager.py", line 212, in get_job_config
1063
    for handler_name, handler_options in processes.items():
1064
AttributeError: 'list' object has no attribute 'items'
```