### PR TITLE
Don't override PATH in subprocess call

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,9 @@ def galaxy_virtualenv(galaxy_root_dir):
         str(galaxy_root_dir / "scripts/common_startup.sh"),
         env={
             "GALAXY_SKIP_CLIENT_BUILD": "1",
-            "GALAXY_VIRTUAL_ENV": virtual_env_dir},
+            "GALAXY_VIRTUAL_ENV": virtual_env_dir,
+            "PATH": os.getenv("PATH"),
+        },
         cwd=str(galaxy_root_dir)
     )
     return virtual_env_dir


### PR DESCRIPTION
When `env` is set in the call to `subprocess`, the `PATH` env variable will be overwritten.
(as per docs: "...If env is not None, it must be a mapping that defines the environment variables for the new process; these are used instead of the default behavior of inheriting the current process’ environment.")

As a  result, if the `virtualenv` command is not in `/usr/local/bin` or `/urs/bin` (I had it in `~/.local/bin/`), the `galaxy_virtualenv` fixture will (silently!) not create the virtual environment. Passing the path explicitly should fix this use case.
