### PR TITLE
Don't use gunicorn logging options with unicornherder

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -84,13 +84,16 @@ class GalaxyUnicornHerderService(Service):
                        " -k galaxy.webapps.galaxy.workers.Worker" \
                        " -b {gunicorn[bind]}" \
                        " --workers={gunicorn[workers]}" \
-                       " --access-logfile {log_dir}/gunicorn.access.log" \
-                       " --error-logfile {log_dir}/gunicorn.error.log --capture-output" \
                        " --config python:galaxy.web_stack.gunicorn_config" \
                        " {gunicorn[preload]}" \
                        " {gunicorn[extra_args]}"
 
-    get_environment = GalaxyGunicornService.get_environment
+    def get_environment(self):
+        environment = self.default_environment.copy()
+        if sys.platform == 'darwin':
+            environment["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
+        environment["GALAXY_CONFIG_LOG_DESTINATION"] = "{log_dir}/gunicorn.log"
+        return environment
 
 
 class GalaxyCeleryService(Service):


### PR DESCRIPTION
use Galaxy's python logging config instead, so that rotation can be performed.

Rotation depends on galaxyproject/galaxy#14457 unless you do a full custom logging config, and the access log entries will be missing from the gunicorn log file (when running under unicornherder) without galaxyproject/galaxy#14467, so this should not be tagged and released until after those are merged.

If you need to set the `log_destination` Galaxy config option from the environment, you can use `$GALAXY_CONFIG_OVERRIDE_LOG_DESTINATION`.