### PR TITLE
If virtualenv is set in the Gravity config, automatically add its bin dir to $PATH if the gx-it-proxy is enabled

### DIFF
--- a/gravity/process_manager/supervisor_manager.py
+++ b/gravity/process_manager/supervisor_manager.py
@@ -306,6 +306,9 @@ class SupervisorProcessManager(BaseProcessManager):
             raise Exception(f"Unknown service type: {service['service_type']}")
 
         environment = self._service_environment(service, attribs)
+        if virtualenv_bin and service.add_virtualenv_to_path:
+            path = environment.get("PATH", "%(ENV_PATH)s")
+            environment["PATH"] = ":".join([virtualenv_bin, path])
         format_vars["environment"] = ",".join("{}={}".format(k, shlex.quote(v.format(**format_vars))) for k, v in environment.items())
 
         with open(conf, "w") as out:

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -30,6 +30,7 @@ class Service(AttributeDict):
     service_name = "_default_"
     environment_from = None
     default_environment = {}
+    add_virtualenv_to_path = False
     graceful_method = GracefulMethod.DEFAULT
 
     def __init__(self, *args, **kwargs):
@@ -127,6 +128,8 @@ class GalaxyGxItProxyService(Service):
     default_environment = {
         "npm_config_yes": "true",
     }
+    # the npx shebang is $!/usr/bin/env node, so $PATH has to be correct
+    add_virtualenv_to_path = True
     command_template = "{virtualenv_bin}npx gx-it-proxy --ip {gx_it_proxy[ip]} --port {gx_it_proxy[port]}" \
                        " --sessions {gx_it_proxy[sessions]} {gx_it_proxy[verbose]}"
 


### PR DESCRIPTION
This doesn't appear if Gravity is installed in your Galaxy venv and the venv is activated when supervisord launches, but is necessary when they are separate.