### PR TITLE
Support converting settings to command line arguments in a generalized way

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -178,7 +178,7 @@ class ConfigManager(object):
             gxit_config.sessions = app_config.get("interactivetools_map", gxit_config.sessions)
             gxit_config.verbose = '--verbose' if gxit_config.verbose else ''
             config.services.append(service_for_service_type("gx-it-proxy")(config_type=config.config_type))
-        config.attribs["gx_it_proxy"] = gravity_config.gx_it_proxy.dict()
+        config.attribs["gx-it-proxy"] = gravity_config.gx_it_proxy.dict()
 
     @staticmethod
     def expand_handlers(gravity_config: Settings, config):

--- a/gravity/process_manager/supervisor_manager.py
+++ b/gravity/process_manager/supervisor_manager.py
@@ -295,6 +295,7 @@ class SupervisorProcessManager(BaseProcessManager):
             "supervisor_state_dir": self.supervisor_state_dir,
             "state_dir": self.state_dir,
         }
+        format_vars["command_arguments"] = service.get_command_arguments(attribs, format_vars)
         format_vars["command"] = service.command_template.format(**format_vars)
         conf = join(instance_conf_dir, f"{service['config_type']}_{service['service_type']}_{service['service_name']}.conf")
 

--- a/gravity/process_manager/supervisor_manager.py
+++ b/gravity/process_manager/supervisor_manager.py
@@ -285,7 +285,7 @@ class SupervisorProcessManager(BaseProcessManager):
             "celery": attribs["celery"],
             "galaxy_infrastructure_url": attribs["galaxy_infrastructure_url"],
             "tusd": attribs["tusd"],
-            "gx_it_proxy": attribs["gx_it_proxy"],
+            "gx_it_proxy": attribs["gx-it-proxy"],
             "galaxy_umask": service.get("umask", "022"),
             "program_name": program_name,
             "process_name_opt": process_name_opt,


### PR DESCRIPTION
It's easy to include Gravity config setting values in the command line template, but only direct value substitutions with minor formatting since the command template is a `str.format()` string, not an f-string. And even if they were f-strings, putting a lot of logic inside the command template string is probably not ideal... So at present, you can't use settings to control the presence of optional flags in the command line. This allows you to do so, and fixes the documented-but-unimplemented `forward_*` and `reverse_proxy` gx-it-proxy settings (fixes #67).

As noted in the FIXME comment, to make an assumption based on the truthiness of the settings value is maybe not the best method for determining whether an optional should be replaced with its `command_arguments` value. Maybe the pydantic model could be of use here, any thoughts @mvdbeek?

This PR also includes a fix for setting env vars under the gx-it-proxy service due to the `service_type` not matching the `attribs` key (dashes instead of underscores). For what it's worth, you can use dict keys with dashes with `**` and in `str.format()` strings:

```pycon
>>> format_vars = {"gx-it-proxy": {"ip": "10.1.1.1", "port": "8080"}}
>>> "npx gx-it-proxy --ip {gx-it-proxy[ip]} --port {gx-it-proxy[port]}".format(**format_vars)
'npx gx-it-proxy --ip 10.1.1.1 --port 8080'
```

If we wanted to be more consistent we could change it in `format_vars` and the command template, but the settings key would still be `gx_it_proxy`. Conversely, we could change the service type and all other references with dashes to underscores.