### PR TITLE
Add --version option to get Gravity version

### DIFF
--- a/gravity/cli.py
+++ b/gravity/cli.py
@@ -65,6 +65,7 @@ class GravityCLI(click.MultiCommand):
 
 # Shortcut for running Galaxy in the foreground
 @click.command(context_settings=CONTEXT_SETTINGS)
+@click.version_option()
 @options.debug_option()
 @options.state_dir_option()
 @options.no_log_option()
@@ -78,6 +79,7 @@ def galaxy(ctx, debug, state_dir, quiet):
 
 
 @click.command(cls=GravityCLI, context_settings=CONTEXT_SETTINGS)
+@click.version_option()
 @options.debug_option()
 @options.state_dir_option()
 @click.pass_context


### PR DESCRIPTION
It'd be useful to get the Galaxy version as well, I'm adding that in the 1.x branch though.