### PR TITLE
Multi-unicorn rolling restart and general multi-instance service support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,14 +298,6 @@ Your proxy server can balance load between the two gunicorns. For example, with 
         }
     }
 
-To perform the readiness check on a gunicorn using a UNIX domain socket as in this example, the `requests-unixsocket`_
-Python library must be installed. This is not installed by default so as not to add an additional dependency to Galaxy,
-but you can install it when installing Gravity with:
-
-.. code:: console
-
-    $ pip install 'gravity[unixsocket]'
-
 Service Instances
 -----------------
 
@@ -912,4 +904,3 @@ is changed.
 .. _job handler assignment method: https://docs.galaxyproject.org/en/master/admin/scaling.html#job-handler-assignment-methods
 .. _dynamically defined handlers: https://docs.galaxyproject.org/en/latest/admin/scaling.html#dynamically-defined-handlers
 .. _Ansible: http://www.ansible.com/
-.. _requests-unixsocket: https://github.com/msabramo/requests-unixsocket

--- a/README.rst
+++ b/README.rst
@@ -437,16 +437,25 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
   gravity:
 
     # Process manager to use.
-    # ``supervisor`` is the default process manager.
-    # ``systemd`` is also supported.
+    # ``supervisor`` is the default process manager when Gravity is invoked as a non-root user.
+    # ``systemd`` is the default when Gravity is invoked as root.
     # Valid options are: supervisor, systemd
-    # process_manager: supervisor
+    # process_manager:
 
     # What command to write to the process manager configs
     # `gravity` (`galaxyctl exec <service-name>`) is the default
     # `direct` (each service's actual command) is also supported.
-    # Valid options are: gravity, direct
+    # Valid options are: gravity, direct, exec
     # service_command_style: gravity
+
+    # Use the process manager's *service instance* functionality for services that can run multiple instances.
+    # Presently this includes services like gunicorn and Galaxy dynamic job handlers. Service instances are only supported if
+    # ``service_command_style`` is ``gravity``, and so this option is automatically set to ``false`` if
+    # ``service_command_style`` is set to ``direct``.
+    # use_service_instances: true
+
+    # umask under which services should be executed. Setting ``umask`` on an individual service overrides this value.
+    # umask: '022'
 
     # Memory limit (in GB), processes exceeding the limit will be killed. Default is no limit. If set, this is default value
     # for all services. Setting ``memory_limit`` on an individual service overrides this value. Ignored if ``process_manager``
@@ -489,7 +498,7 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
     # this is hidden from you when running a single instance.
     # instance_name: _default_
 
-    # Configuration for Gunicorn.
+    # Configuration for Gunicorn. Can be a list to run multiple gunicorns for rolling restarts.
     gunicorn:
 
       # Enable Galaxy gunicorn server.
@@ -557,6 +566,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # Extra arguments to pass to Celery command line.
       # extra_args:
 
+      # umask under which service should be executed
+      # umask:
+
       # Value of supervisor startsecs, systemd TimeoutStartSec
       # start_timeout: 10
 
@@ -585,7 +597,8 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # port: 4002
 
       # Routes file to monitor.
-      # Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section.
+      # Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section. This is ignored if
+      # ``interactivetools_map is set``.
       # sessions: database/interactivetools_map.sqlite
 
       # Include verbose messages in gx-it-proxy
@@ -602,6 +615,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # Rewrite location blocks with proxy port.
       # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
       # reverse_proxy: false
+
+      # umask under which service should be executed
+      # umask:
 
       # Value of supervisor startsecs, systemd TimeoutStartSec
       # start_timeout: 10
@@ -654,6 +670,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # Extra arguments to pass to tusd command line.
       # extra_args:
 
+      # umask under which service should be executed
+      # umask:
+
       # Value of supervisor startsecs, systemd TimeoutStartSec
       # start_timeout: 10
 
@@ -702,6 +721,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
 
       # Extra arguments to pass to Gunicorn command line.
       # extra_args:
+
+      # umask under which service should be executed
+      # umask:
 
       # Value of supervisor startsecs, systemd TimeoutStartSec
       # start_timeout: 10

--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,29 @@ commands:
 ``galayxctl follow``                ``journalctl -f -u 'galaxy-*'``
 =================================== ==================================================================
 
+Zero Downtime Restarts
+----------------------
+
+something about unicornherder
+
+e.g. to
+run two gunicorn instances on ports 8080 and 8081:
+  instance_count: 2
+  bind: localhost:808{instance_number}
+
+this looks a little nicer:
+
+  instance_count: 2
+  instance_number_start: 8080
+  bind: localhost:{instance_number}
+
+for unix sockets:
+
+  instance_count: 2
+  bind: unix:/run/gunicorn{instance_number}.sock
+
+service names become ``gunicorn:{instance_number}``
+
 Managing Multiple Galaxies
 --------------------------
 

--- a/gravity/commands/cmd_exec.py
+++ b/gravity/commands/cmd_exec.py
@@ -6,7 +6,7 @@ from gravity import process_manager
 
 @click.command("exec")
 @click.option("--no-exec", "-n", is_flag=True, default=False, help="Don't exec, just print the command that would be run")
-@click.option("--service-instance", "-i", type=str, help="For multi-instance services, which instance to exec")
+@click.option("--service-instance", "-i", type=int, help="For multi-instance services, which instance to exec")
 @options.instances_services_arg()
 @click.pass_context
 def cli(ctx, instances_services, no_exec, service_instance):
@@ -18,4 +18,4 @@ def cli(ctx, instances_services, no_exec, service_instance):
     Exactly one service name is required in SERVICES.
     """
     with process_manager.process_manager(**ctx.parent.cm_kwargs) as pm:
-        pm.exec(instance_names=instances_services, service_instance=service_instance, no_exec=no_exec)
+        pm.exec(instance_names=instances_services, service_instance_number=service_instance, no_exec=no_exec)

--- a/gravity/commands/cmd_exec.py
+++ b/gravity/commands/cmd_exec.py
@@ -6,7 +6,7 @@ from gravity import process_manager
 
 @click.command("exec")
 @click.option("--no-exec", "-n", is_flag=True, default=False, help="Don't exec, just print the command that would be run")
-@click.option("--service-instance", "-i", type=int, help="For multi-instance services, which instance to exec")
+@click.option("--service-instance", "-i", type=str, help="For multi-instance services, which instance to exec")
 @options.instances_services_arg()
 @click.pass_context
 def cli(ctx, instances_services, no_exec, service_instance):
@@ -18,4 +18,4 @@ def cli(ctx, instances_services, no_exec, service_instance):
     Exactly one service name is required in SERVICES.
     """
     with process_manager.process_manager(**ctx.parent.cm_kwargs) as pm:
-        pm.exec(instance_names=instances_services, service_instance_number=service_instance, no_exec=no_exec)
+        pm.exec(instance_names=instances_services, service_instance=service_instance, no_exec=no_exec)

--- a/gravity/commands/cmd_exec.py
+++ b/gravity/commands/cmd_exec.py
@@ -6,9 +6,10 @@ from gravity import process_manager
 
 @click.command("exec")
 @click.option("--no-exec", "-n", is_flag=True, default=False, help="Don't exec, just print the command that would be run")
+@click.option("--service-instance", "-i", type=int, help="For multi-instance services, which instance to exec")
 @options.instances_services_arg()
 @click.pass_context
-def cli(ctx, instances_services, no_exec):
+def cli(ctx, instances_services, no_exec, service_instance):
     """Run a single Galaxy service in the foreground, with logging output to stdout/stderr.
 
     Zero or one instance names can be provided in INSTANCES, it is required if more than one Galaxy instance is
@@ -17,4 +18,4 @@ def cli(ctx, instances_services, no_exec):
     Exactly one service name is required in SERVICES.
     """
     with process_manager.process_manager(**ctx.parent.cm_kwargs) as pm:
-        pm.exec(instance_names=instances_services, no_exec=no_exec)
+        pm.exec(instance_names=instances_services, service_instance_number=service_instance, no_exec=no_exec)

--- a/gravity/commands/cmd_start.py
+++ b/gravity/commands/cmd_start.py
@@ -19,6 +19,7 @@ def cli(ctx, instances_services, foreground, quiet=False):
     """
     auto_update = False
     if not instances_services and not ctx.parent.cm_kwargs["config_file"]:
+        # FIXME: this doesn't do anything anymore now that the cm goes out of scope. you just init the cm twice
         with config_manager.config_manager(**ctx.parent.cm_kwargs) as cm:
             # If there are no configs known, we will attempt to auto-load one
             cm.auto_load()

--- a/gravity/commands/cmd_start.py
+++ b/gravity/commands/cmd_start.py
@@ -1,8 +1,8 @@
 import click
 
-from gravity import config_manager, options
+from gravity import options
 from gravity import process_manager
-from gravity.io import info, exception
+from gravity.io import info
 
 
 @click.command("start")
@@ -17,20 +17,8 @@ def cli(ctx, instances_services, foreground, quiet=False):
 
     Specifying INSTANCES and SERVICES limits the operation to only the provided instance name(s) and/or service(s).
     """
-    auto_update = False
-    if not instances_services and not ctx.parent.cm_kwargs["config_file"]:
-        # FIXME: this doesn't do anything anymore now that the cm goes out of scope. you just init the cm twice
-        with config_manager.config_manager(**ctx.parent.cm_kwargs) as cm:
-            # If there are no configs known, we will attempt to auto-load one
-            cm.auto_load()
-            auto_update = True
-        if not cm.instance_count:
-            exception(
-                "Nothing to start: no Galaxy instances configured and no Galaxy configuration files found, "
-                "see `galaxyctl --help`")
     with process_manager.process_manager(foreground=foreground, **ctx.parent.cm_kwargs) as pm:
-        if auto_update:
-            pm.update()
+        pm.update()
         pm.start(instance_names=instances_services)
         if foreground:
             pm.follow(instance_names=instances_services, quiet=quiet)

--- a/gravity/commands/cmd_status.py
+++ b/gravity/commands/cmd_status.py
@@ -1,11 +1,19 @@
 import click
 
+from gravity import options
 from gravity import process_manager
 
 
 @click.command("status")
+@options.instances_services_arg()
 @click.pass_context
-def cli(ctx):
-    """Display server status."""
+def cli(ctx, instances_services):
+    """Display server status.
+
+    If no INSTANCES or SERVICES are provided, the status of all configured services of all configured instances is
+    displayed.
+
+    Specifying INSTANCES and SERVICES limits the operation to only the provided instance name(s) and/or service(s).
+    """
     with process_manager.process_manager(**ctx.parent.cm_kwargs) as pm:
-        pm.status()
+        pm.status(instance_names=instances_services)

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -156,7 +156,7 @@ class ConfigManager(object):
         }
 
         # some things should only be included if set
-        for app_key in ("interactivetools_map",):
+        for app_key in ("interactivetools_map", "galaxy_url_prefix"):
             if app_key in app_config:
                 app_config_dict[app_key] = app_config[app_key]
 

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from yaml import safe_load
 
 import gravity.io
-from gravity.settings import ServiceCommandStyle, Settings
+from gravity.settings import Settings
 from gravity.state import (
     ConfigFile,
     service_for_service_type,
@@ -244,7 +244,7 @@ class ConfigManager(object):
 
     @staticmethod
     def expand_handlers(gravity_settings: Settings, config: ConfigFile):
-        use_list = gravity_settings.service_command_style == ServiceCommandStyle.gravity
+        use_list = gravity_settings.use_service_instances
         handlers = gravity_settings.handlers or {}
         expanded_handlers = {}
         default_name_template = "{name}_{process}"

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -130,162 +130,129 @@ class ConfigManager(object):
     def __load_config(self, gravity_config_dict, app_config):
         defaults = {}
         try:
-            gravity_config = Settings(**recursive_update(defaults, gravity_config_dict))
+            gravity_settings = Settings(**recursive_update(defaults, gravity_config_dict))
         except ValidationError as exc:
             # suppress the traceback and just report the error
             gravity.io.exception(exc)
 
-        if gravity_config.instance_name in self.__configs:
+        if gravity_settings.instance_name in self.__configs:
             gravity.io.error(
-                f"Galaxy instance {gravity_config.instance_name} already loaded from file: "
-                f"{self.__configs[gravity_config.instance_name].gravity_config_file}")
-            gravity.io.exception(f"Duplicate instance name {gravity_config.instance_name}, instance names must be unique")
+                f"Galaxy instance {gravity_settings.instance_name} already loaded from file: "
+                f"{self.__configs[gravity_settings.instance_name].gravity_config_file}")
+            gravity.io.exception(f"Duplicate instance name {gravity_settings.instance_name}, instance names must be unique")
 
         gravity_config_file = gravity_config_dict["__file__"]
         galaxy_config_file = app_config.get("__file__", gravity_config_file)
-
-        service_settings = {}
-        if isinstance(gravity_config.gunicorn, list):
-            service_settings["gunicorn"] = [g.dict() for g in gravity_config.gunicorn]
-        else:
-            service_settings["gunicorn"] = gravity_config.gunicorn.dict()
-        service_settings["tusd"] = gravity_config.tusd.dict()
-        service_settings["celery"] = gravity_config.celery.dict()
-        service_settings["reports"] = gravity_config.reports.dict()
-
-        galaxy_root = gravity_config.galaxy_root or app_config.get("root")
+        galaxy_root = gravity_settings.galaxy_root or app_config.get("root")
 
         # TODO: document that the default state_dir is data_dir/gravity and that setting state_dir overrides this
         gravity_data_dir = self.state_dir or os.path.join(app_config.get("data_dir", "database"), "gravity")
-        log_dir = gravity_config.log_dir or os.path.join(gravity_data_dir, "log")
+        log_dir = gravity_settings.log_dir or os.path.join(gravity_data_dir, "log")
+
+        # TODO: this should use galaxy.util.properties.load_app_properties() so that env vars work
+        app_config_dict = {
+            "galaxy_infrastructure_url": app_config.get("galaxy_infrastructure_url", "").rstrip("/"),
+            "interactivetools_enable": app_config.get("interactivetools_enable"),
+        }
+
+        # some things should only be included if set
+        for app_key in ("interactivetools_map",):
+            if app_key in app_config:
+                app_config_dict[app_key] = app_config[app_key]
 
         config = ConfigFile(
             config_type=self.galaxy_server_config_section,
+            app_config=app_config_dict,
             gravity_config_file=gravity_config_file,
             galaxy_config_file=galaxy_config_file,
-            instance_name=gravity_config.instance_name,
-            process_manager=gravity_config.process_manager,
-            service_command_style=gravity_config.service_command_style,
-            app_server=gravity_config.app_server,
-            virtualenv=gravity_config.virtualenv,
-            galaxy_infrastructure_url=app_config.get("galaxy_infrastructure_url", "").rstrip("/"),
+            instance_name=gravity_settings.instance_name,
+            process_manager=gravity_settings.process_manager,
+            service_command_style=gravity_settings.service_command_style,
+            app_server=gravity_settings.app_server,
+            virtualenv=gravity_settings.virtualenv,
             galaxy_root=galaxy_root,
-            galaxy_user=gravity_config.galaxy_user,
-            galaxy_group=gravity_config.galaxy_group,
-            umask=gravity_config.umask,
-            memory_limit=gravity_config.memory_limit,
+            galaxy_user=gravity_settings.galaxy_user,
+            galaxy_group=gravity_settings.galaxy_group,
+            umask=gravity_settings.umask,
+            memory_limit=gravity_settings.memory_limit,
             gravity_data_dir=gravity_data_dir,
             log_dir=log_dir,
         )
 
-        service_kwargs = {
-            "config": config,
-            "service_settings": service_settings,
-        }
+        # add standard services if enabled
+        for service_type in (config.app_server, "celery", "celery-beat", "tusd", "gx-it-proxy", "reports"):
+            config.services.extend(service_for_service_type(service_type).services_if_enabled(config, gravity_settings))
 
-        # TODO: don't allow gunicorn list + unicornherder
-        # TODO: do this better
-        if isinstance(gravity_config.gunicorn, list):
-            gunicorn_services = []
-            for i, gunicorn in enumerate(gravity_config.gunicorn):
-                if gunicorn.enable:
-                    settings = service_settings["gunicorn"][i]
-                    service_kwargs = {"config": config, "settings": settings}
-                    gunicorn_services.append(service_for_service_type("gunicorn")(**service_kwargs))
-            if gravity_config.service_command_style == ServiceCommandStyle.direct:
-                # service instances have to be separate files if writing direct, since command lines vary by more than
-                # just a single templatable integer/string
-                # TODO: test this
-                config.services.extend(gunicorn_services)
-            else:
-                config.services.append(service_for_service_type("_list_")(services=gunicorn_services, service_name="gunicorn"))
-        elif gravity_config.gunicorn.enable:
-            settings = service_settings["gunicorn"]
-            service_kwargs = {"config": config, "settings": settings}
-            config.services.append(service_for_service_type(config.app_server)(**service_kwargs))
+        # TODO: document that only environment can be configured on static handlers, dynamic handlers can have any of
+        # the common settings (memory_limit, etc.)
 
-        if gravity_config.celery.enable:
-            settings = service_settings["celery"]
-            service_kwargs = {"config": config, "settings": settings}
-            config.services.append(service_for_service_type("celery")(**service_kwargs))
-        if gravity_config.celery.enable_beat:
-            settings = service_settings["celery"]
-            service_kwargs = {"config": config, "settings": settings}
-            config.services.append(service_for_service_type("celery-beat")(**service_kwargs))
-        if gravity_config.tusd.enable:
-            settings = service_settings["tusd"]
-            service_kwargs = {"config": config, "settings": settings}
-            config.services.append(service_for_service_type("tusd")(**service_kwargs))
-        if gravity_config.reports.enable:
-            settings = service_settings["reports"]
-            service_kwargs = {"config": config, "settings": settings}
-            config.services.append(service_for_service_type("reports")(**service_kwargs))
+        # load any static handlers defined in the galaxy job config
+        assign_with = self.create_static_handler_services(config, app_config)
 
-        # FIXME: handlers
+        # load any dynamic handlers defined in the gravity config
+        self.create_dynamic_handler_services(gravity_settings, config, assign_with)
 
+        for service in config.services:
+            gravity.io.debug(f"Configured {service.service_type} type service: {service.service_name}")
+        gravity.io.debug(f"Loaded instance {config.instance_name} from Gravity config file: {config.gravity_config_file}")
+
+        self.__configs[config.instance_name] = config
+        return config
+
+    def create_static_handler_services(self, config: ConfigFile, app_config: dict):
+        assign_with = None
         if not app_config.get("job_config_file") and app_config.get("job_config"):
             # config embedded directly in Galaxy config
             job_config = app_config["job_config"]
         else:
-            # If this is a Galaxy config, parse job_conf.xml for any *static* standalone handlers
+            # config in an external file
             job_config = app_config.get("job_config_file", DEFAULT_JOB_CONFIG_FILE)
             if not os.path.isabs(job_config):
                 job_config = os.path.abspath(os.path.join(os.path.dirname(config.galaxy_config_file), job_config))
                 if not os.path.exists(job_config):
                     job_config = None
-        if config.config_type == "galaxy" and job_config:
-            for handler_settings in ConfigManager.get_job_config(job_config):
+        if job_config:
+            # parse job conf for any *static* standalone handlers
+            assign_with, handler_settings_list = ConfigManager.get_job_config(job_config)
+            for handler_settings in handler_settings_list:
                 config.services.append(service_for_service_type("standalone")(
                     config=config,
                     service_name=handler_settings.pop("service_name"),
-                    service_settings={"standalone": handler_settings},
+                    settings=handler_settings,
                 ))
+        return assign_with
 
-        # FIXME: This should imply explicit configuration of the handler assignment method. If not explicitly set, the
-        # web process will be a handler, which is not desirable when dynamic handlers are used. Currently Gravity
-        # doesn't parse that part of the job config. See logic in lib/galaxy/web_stack/handlers.py _get_is_handler() to
-        # see how this is determined.
-        self.create_handler_services(gravity_config, config)
-        self.create_gxit_services(gravity_config, app_config, config)
-        self.__configs[config.instance_name] = config
-        gravity.io.debug(f"Loaded instance {config.instance_name} from Gravity config file: {config.gravity_config_file}")
-        return config
-
-    def create_handler_services(self, gravity_config: Settings, config):
-        # we pull push environment from settings to services but the rest of the services pull their env options from
+    def create_dynamic_handler_services(self, gravity_settings: Settings, config: ConfigFile, assign_with):
+        # we push environment from settings to services but the rest of the services pull their env options from
         # settings directly. this can be a bit confusing but is probably ok since there are 3 ways to configure
         # handlers, and gravity is only 1 of them.
-        expanded_handlers = self.expand_handlers(gravity_config, config)
+        assign_with = assign_with or []
+        expanded_handlers = self.expand_handlers(gravity_settings, config)
+        if expanded_handlers and "db-skip-locked" not in assign_with and "db-transaction-isolation" not in assign_with:
+            gravity.io.warn(
+                "Dynamic handlers are configured in Gravity but Galaxy is not configured to assign jobs to handlers "
+                "dynamically, so these handlers will not handle jobs. Set the job handler assignment method in the "
+                "Galaxy job configuration to `db-skip-locked` or `db-transaction-isolation` to fix this.")
         for service_name, handler_settings in expanded_handlers.items():
-            if "pools" in handler_settings:
-                handler_settings["server_pools"] = handler_settings.pop("pools")
-            config.services.append(
-                service_for_service_type("standalone")(
-                    config=config,
+            config.services.extend(
+                service_for_service_type("standalone").services_if_enabled(
+                    config,
+                    gravity_settings=gravity_settings,
+                    settings=handler_settings,
                     service_name=service_name,
-                    service_settings={"standalone": handler_settings},
                 ))
 
-    def create_gxit_services(self, gravity_config: Settings, app_config, config):
-        interactivetools_enable = app_config.get("interactivetools_enable")
-        if gravity_config.gx_it_proxy.enable and not interactivetools_enable:
-            gravity.io.exception("To run the gx-it-proxy server you need to set interactivetools_enable in the galaxy section of galaxy.yml")
-        if gravity_config.gx_it_proxy.enable:
-            # TODO: resolve against data_dir, or bring in galaxy-config ?
-            # CWD in supervisor template is galaxy_root, so this should work for simple cases as is
-            gxit_config = gravity_config.gx_it_proxy
-            gxit_config.sessions = app_config.get("interactivetools_map", gxit_config.sessions)
-            # technically the tusd service doesn't have access to the rest of the settings like other services do, but it doesn't need it
-            service_kwargs = dict(config=config, service_settings={"gx-it-proxy": gravity_config.gx_it_proxy.dict()})
-            config.services.append(service_for_service_type("gx-it-proxy")(**service_kwargs))
-
     @staticmethod
-    def expand_handlers(gravity_config: Settings, config):
-        handlers = gravity_config.handlers or {}
+    def expand_handlers(gravity_settings: Settings, config: ConfigFile):
+        use_list = gravity_settings.service_command_style == ServiceCommandStyle.gravity
+        handlers = gravity_settings.handlers or {}
         expanded_handlers = {}
         default_name_template = "{name}_{process}"
         for service_name, handler_config in handlers.items():
+            handler_config["enable"] = True
             count = handler_config.get("processes", 1)
+            if "pools" in handler_config:
+                handler_config["server_pools"] = handler_config.pop("pools")
             name_template = handler_config.get("name_template")
             if name_template is None:
                 if count == 1 and service_name[-1].isdigit():
@@ -293,23 +260,36 @@ class ConfigManager(object):
                     expanded_handlers[service_name] = handler_config
                     continue
             name_template = (name_template or default_name_template).strip()
+            instances = []
             for index in range(count):
                 expanded_service_name = name_template.format(name=service_name, process=index, instance_name=config.instance_name)
-                if expanded_service_name not in expanded_handlers:
+                if use_list:
+                    instance = handler_config.copy()
+                    instance["server_name"] = expanded_service_name
+                    instances.append(instance)
+                elif expanded_service_name not in expanded_handlers:
                     expanded_handlers[expanded_service_name] = handler_config
+                else:
+                    gravity.io.warn(f"Duplicate handler name after expansion: {expanded_service_name}")
+            if use_list:
+                expanded_handlers[service_name] = instances
         return expanded_handlers
 
     @staticmethod
     def get_job_config(conf: Union[str, dict]):
         """Extract handler names from job_conf.xml"""
         # TODO: use galaxy job conf parsing
+        assign_with = None
         rval = []
         if isinstance(conf, str):
             if conf.endswith('.xml'):
                 root = elementtree.parse(conf).getroot()
-                for handler in (root.find("handlers") or []):
+                handlers = root.find("handlers")
+                assign_with = (handlers or {}).get("assign_with")
+                if assign_with:
+                    assign_with = [a.strip() for a in assign_with.split(",")]
+                for handler in (handlers or []):
                     rval.append({"service_name": handler.attrib["id"]})
-                return rval
             elif conf.endswith(('.yml', '.yaml')):
                 with open(conf) as job_conf_fh:
                     conf = safe_load(job_conf_fh.read())
@@ -317,13 +297,14 @@ class ConfigManager(object):
                 gravity.io.exception(f"Unknown job config file type: {conf}")
         if isinstance(conf, dict):
             handling = conf.get('handling') or {}
+            assign_with = handling.get('assign', [])
             processes = handling.get('processes') or {}
             for handler_name, handler_options in processes.items():
                 rval.append({
                     "service_name": handler_name,
                     "environment": (handler_options or {}).get("environment", None)
                 })
-        return rval
+        return (assign_with, rval)
 
     @property
     def instance_count(self):

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -7,6 +7,7 @@ import os
 import xml.etree.ElementTree as elementtree
 from typing import Union
 
+from pydantic import ValidationError
 from yaml import safe_load
 
 from gravity.settings import Settings
@@ -128,7 +129,11 @@ class ConfigManager(object):
 
     def __load_config(self, gravity_config_dict, app_config):
         defaults = {}
-        gravity_config = Settings(**recursive_update(defaults, gravity_config_dict))
+        try:
+            gravity_config = Settings(**recursive_update(defaults, gravity_config_dict))
+        except ValidationError as exc:
+            # suppress the traceback and just report the error
+            exception(exc)
 
         if gravity_config.instance_name in self.__configs:
             error(

--- a/gravity/io.py
+++ b/gravity/io.py
@@ -14,10 +14,13 @@ def debug(message, *args):
         click.echo(message)
 
 
-def info(message, *args):
+def info(message, *args, bright=True):
     if args:
         message = message % args
-    click.echo(click.style(message, bold=True, fg="green"))
+    style_kwargs = {}
+    if bright:
+        style_kwargs = {"bold": True, "fg": "green"}
+    click.echo(click.style(message, **style_kwargs))
 
 
 def error(message, *args):

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -38,9 +38,7 @@ def _route(func, all_process_managers=False):
         configs = self.config_manager.get_configs(instances=instance_names or None)
         for config in configs:
             for service in config.services:
-                # ensure all services have format vars set before passed to the routed function - maybe this is
-                # inefficient though? could add a "route_with_format_vars" if needed
-                service.format_vars = self.process_managers[config.process_manager].service_format_vars(config, service)
+                service.var_formatter = partial(self.process_managers[config.process_manager].service_format_vars, config)
             try:
                 configs_by_pm[config.process_manager].append(config)
             except KeyError:
@@ -92,7 +90,6 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
         format_vars = {
             "config_type": service.config_type,
             "server_name": service.service_name,
-            "program_name": program_name,
             "galaxy_infrastructure_url": config.galaxy_infrastructure_url,
             "galaxy_umask": service.settings.get("umask") or config.umask,
             "galaxy_conf": config.galaxy_config_file,

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -37,10 +37,6 @@ def _route(func, all_process_managers=False):
         instance_names, service_names = self._instance_service_names(instance_names)
         configs = self.config_manager.get_configs(instances=instance_names or None)
         for config in configs:
-            for service in config.services:
-                # TODO: not sure this is really necessary, originally it was to store format vars on the service, but do
-                # we need that?
-                service.var_formatter = partial(self.process_managers[config.process_manager].service_format_vars, config)
             try:
                 configs_by_pm[config.process_manager].append(config)
             except KeyError:
@@ -129,9 +125,6 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
             format_vars["command"] = f"{galaxyctl} --config-file {config_file} exec{instance_number_opt} {config.instance_name} {service.service_name}"
             environment = {}
         format_vars["environment"] = self._service_environment_formatter(environment, format_vars)
-
-        # FIXME: do we actually need to do this?
-        #service.format_vars = format_vars
 
         return format_vars
 

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -346,7 +346,7 @@ class ProcessManagerRouter:
         """ """
 
     @route
-    def status(self):
+    def status(self, instance_names=None):
         """ """
 
     @route_to_all

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -92,12 +92,12 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
         format_vars = {
             "config_type": service.config_type,
             "server_name": service.service_name,
-            "galaxy_infrastructure_url": config.galaxy_infrastructure_url,
             "galaxy_umask": service.settings.get("umask") or config.umask,
             "galaxy_conf": config.galaxy_config_file,
             "galaxy_root": config.galaxy_root,
             "virtualenv_bin": virtualenv_bin,
             "gravity_data_dir": config.gravity_data_dir,
+            "app_config": config.app_config,
         }
 
         format_vars["settings"] = service.settings
@@ -309,7 +309,7 @@ class ProcessManagerRouter:
                 exception("No provided names are known instance or service names")
         return (instance_names, service_names)
 
-    def exec(self, instance_names=None, service_instance=None, no_exec=False):
+    def exec(self, instance_names=None, service_instance_number=None, no_exec=False):
         """ """
         instance_names, service_names = self._instance_service_names(instance_names)
 
@@ -330,12 +330,6 @@ class ProcessManagerRouter:
             exception(f"Service '{service_name}' is not configured. Configured service(s): {service_list}")
 
         service = services[0]
-
-        # translate the instance name from the PM back into a list index
-        pm = self.process_managers[config.process_manager]
-        service_instance_number = pm.service_instance_number(config, service, service_instance)
-        debug(f"Service instance name '{service_instance}' -> number '{service_instance_number}'")
-
         return self._process_executor.exec(config, service, service_instance_number=service_instance_number, no_exec=no_exec)
 
     @route

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -100,6 +100,11 @@ class SupervisorProgram:
             self.config_instance_program_name += "_%(process_num)d"
 
     @property
+    def config_file_name(self):
+        service = self.service
+        return f"{service.config_type}_{service.service_type}_{service.service_name}.conf"
+
+    @property
     def config_program_name(self):
         """The representation in [program:NAME] in the supervisor config"""
         service = self.service
@@ -213,7 +218,7 @@ class SupervisorProcessManager(BaseProcessManager):
 
         format_vars = self._service_format_vars(config, service, supervisor_format_vars)
 
-        conf = join(instance_conf_dir, f"{service.config_type}_{service.service_type}_{service.service_name}.conf")
+        conf = join(instance_conf_dir, program.config_file_name)
         template = SUPERVISORD_SERVICE_TEMPLATE
         contents = template.format(**format_vars)
         name = service.service_name if not self._use_instance_name else f"{instance_name}:{service.service_name}"
@@ -239,7 +244,6 @@ class SupervisorProcessManager(BaseProcessManager):
             intended_configs.add(self.__update_service(config, service, instance_conf_dir, instance_name))
             programs.append(f"{instance_name}_{service.config_type}_{service.service_type}_{service.service_name}")
 
-        # TODO: test group mode
         group_conf = join(self.supervisord_conf_dir, f"group_{instance_name}.conf")
         if self._use_instance_name:
             format_vars = {"instance_name": instance_name, "programs": ",".join(programs)}
@@ -282,7 +286,6 @@ class SupervisorProcessManager(BaseProcessManager):
         return [SupervisorProgram(config, service, self._use_instance_name) for service in services]
 
     def __supervisor_program_names(self, config, service_names):
-        #return [p.program_names for p in self.__supervisor_programs(config, service_names) for p.program_names in p]
         program_names = []
         for program in self.__supervisor_programs(config, service_names):
             program_names.extend(program.program_names)

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -75,6 +75,59 @@ if "XDG_CONFIG_HOME" in os.environ:
     DEFAULT_STATE_DIR = join(os.environ["XDG_CONFIG_HOME"], "galaxy-gravity")
 
 
+class SupervisorProgram:
+    # converts between different formats
+    def __init__(self, config, service, use_instance_name):
+        self.config = config
+        self.service = service
+        self._use_instance_name = use_instance_name
+
+        self.config_process_name = "%(program_name)s"
+        if self._use_instance_name:
+            self.config_process_name = service["service_name"]
+
+        service_settings = service.get_settings()
+        self.config_numprocs = service_settings.get("instance_count", 1)
+        self.config_numprocs_start = service_settings.get("instance_number_start", 0)
+
+        if service.supports_multiple_instances and self.config_numprocs > 1:
+            if self._use_instance_name:
+                self.config_process_name = f"{service['service_name']}%(process_num)d"
+            else:
+                self.config_process_name = "%(process_num)d"
+
+    @property
+    def config_program_name(self):
+        """The representation in [program:NAME] in the supervisor config"""
+        service = self.service
+        if self._use_instance_name:
+            instance_name = self.config.instance_name
+            return f"{instance_name}_{service['config_type']}_{service['service_type']}_{service['service_name']}"
+        else:
+            return service["service_name"]
+
+    @property
+    def program_names(self):
+        """The representation when performing commands, after group and procnums expansion"""
+        instance_name = None
+        if self._use_instance_name:
+            instance_name = self.config.instance_name
+        service_name = self.service["service_name"]
+        service_settings = self.service.get_settings()
+        instance_count = service_settings.get("instance_count", 1)
+        instance_number_start = service_settings.get("instance_number_start", 0)
+        return supervisor_program_names(service_name, instance_count, instance_number_start, instance_name=instance_name)
+
+    @property
+    def instance_numbers(self):
+        """ """
+        service_settings = self.service.get_settings()
+        instance_count = service_settings.get("instance_count", 1)
+        instance_number_start = service_settings.get("instance_number_start", 0)
+        return range(instance_number_start, instance_number_start + instance_count)
+
+
+
 class SupervisorProcessManager(BaseProcessManager):
 
     name = ProcessManager.supervisor
@@ -148,61 +201,30 @@ class SupervisorProcessManager(BaseProcessManager):
     def _service_environment_formatter(self, environment, format_vars):
         return ",".join("{}={}".format(k, shlex.quote(v.format(**format_vars))) for k, v in environment.items())
 
-    def __supervisor_config_program_name(self, instance_name, service):
-        if self._use_instance_name:
-            return f"{instance_name}_{service.config_type}_{service.service_type}_{service.service_name}"
-        else:
-            return service.service_name
-
-    def __supervisor_program_names(self, config, service_names):
-        instance_name = None
-        if self._use_instance_name:
-            instance_name = config.instance_name
-        services = [s for s in config.services if s["service_name"] in service_names]
-        program_names = []
-        for service in services:
-            service_name = service["service_name"]
-            instance_count = service.settings.get("instance_count", 1)
-            instance_number_start = service.settings.get("instance_number_start", 0)
-            program_names.extend(
-                supervisor_program_names(service_name, instance_count, instance_number_start, instance_name=instance_name))
-        return program_names
-
     def terminate(self):
         if self.foreground:
             # if running in foreground, if terminate is called, then supervisord should've already received a SIGINT
             self.__supervisord_popen and self.__supervisord_popen.wait()
 
-    def __update_service(self, config, service, instance_conf_dir, instance_name):
-        # FIXME: follow needs this as well
-        process_name = "%(program_name)s"
-        if self._use_instance_name:
-            process_name = service["service_name"]
-        instance_count = service.settings.get("instance_count", 1)
-        if service.supports_multiple_instances and instance_count > 1:
-            if self._use_instance_name:
-                process_name = f"{service['service_name']}%(process_num)d"
-            else:
-                process_name = "%(process_num)d"
-
+    def service_format_vars(self, config, service):
+        program = SupervisorProgram(config, service, self._use_instance_name)
         # supervisor-specific format vars
         supervisor_format_vars = {
             "log_dir": config.log_dir,
-            "log_file": self._service_log_file(config.log_dir, process_name),
+            "log_file": self._service_log_file(config.log_dir, program.config_program_name),
             "instance_number": "%(process_num)d",
-            "supervisor_program_name": self.__supervisor_config_program_name(instance_name, service),
-            "supervisor_process_name": process_name,
+            "supervisor_program_name": program.config_program_name,
+            "supervisor_process_name": program.config_process_name,
         }
 
-        format_vars = self._service_format_vars(config, service, supervisor_format_vars)
+        return self._service_format_vars(config, service, supervisor_format_vars)
 
+    def __update_service(self, config, service, instance_conf_dir, instance_name):
         conf = join(instance_conf_dir, f"{service.config_type}_{service.service_type}_{service.service_name}.conf")
-
         template = SUPERVISORD_SERVICE_TEMPLATE
-        contents = template.format(**format_vars)
+        contents = template.format(**service.format_vars)
         name = service["service_name"] if not self._use_instance_name else f"{instance_name}:{service['service_name']}"
         self._update_file(conf, contents, name, "service")
-
         return conf
 
     def _process_config(self, config):
@@ -262,6 +284,13 @@ class SupervisorProcessManager(BaseProcessManager):
                 info(f"Removing instance directory {path}")
                 shutil.rmtree(path)
 
+    def __supervisor_programs(self, config, service_names):
+            services = [s for s in config.services if s["service_name"] in service_names]
+            return [SupervisorProgram(config, service, self._use_instance_name) for service in services]
+
+    def __supervisor_program_names(self, config, service_names):
+            return [p.program_names for p in self.__supervisor_programs(config, service_names) for p.program_names in p]
+
     def __start_stop(self, op, configs, service_names):
         targets = []
         for config in configs:
@@ -280,26 +309,28 @@ class SupervisorProcessManager(BaseProcessManager):
             else:
                 services = config.services
             for service in services:
-                program_names = self.__supervisor_program_names(config, [service.service_name])
+                program = self.__supervisor_programs(config, [service.service_name])[0]
                 graceful_method = service.graceful_method
                 if graceful_method == GracefulMethod.SIGHUP:
-                    self.supervisorctl("signal", "SIGHUP", *program_name)
+                    self.supervisorctl("signal", "SIGHUP", *program.program_names)
                 elif graceful_method == GracefulMethod.ROUND_ROBIN:
-                    self.__round_robin(config, service, program_names)
+                    self.__round_robin(config, service, program)
                 else:
-                    self.supervisorctl("restart", *program_names)
+                    self.supervisorctl("restart", *program.program_names)
 
-    def __round_robin(self, config, service, program_names):
+    def __round_robin(self, config, service, program):
         debug(f"#### ROUND ROBIN! {service['service_name']}")
-        for instance_number, program_name in enumerate(program_names):
+        for instance_number in program.instance_numbers:
             # FIXME: no, you should not be pulling the instance number out like this, not even valid when the start > 0
             # really just need to do store format vars or formatted vars
-            format_vars = self._service_format_vars(config, service, {"instance_number": instance_number})
-            self.supervisorctl("restart", program_name)
-            while not service.is_ready(config.attribs, format_vars):
-                import time
-                time.sleep(1)
-                debug("#### SLEP")
+            print(f"#### {instance_number}: {service['service_name']}")
+            GREAT THIS WORKS JUST NEED TO TEMPLATE BIND WITH INSTANCE_NUMBER
+            #format_vars = self._service_format_vars(config, service, {"instance_number": instance_number})
+            #self.supervisorctl("restart", program_name)
+            #while not service.is_ready(config.attribs, format_vars):
+            #    import time
+            #    time.sleep(1)
+            #    debug("#### SLEP")
             # gonna need a timeout here
 
     def start(self, configs=None, service_names=None):

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -98,11 +98,6 @@ class SupervisorProgram:
             else:
                 self.config_process_name = "%(process_num)d"
             self.config_instance_program_name += "_%(process_num)d"
-            # gets from the first
-            try:
-                self.config_numprocs_start = int(service.settings["instance_name"])
-            except (TypeError, ValueError) as exc:
-                gravity.io.exception(f"Invalid value for instance_name (must be an integer with supervisor): {exc}")
 
     @property
     def config_program_name(self):
@@ -124,20 +119,6 @@ class SupervisorProgram:
         instance_count = self.config_numprocs
         instance_number_start = self.config_numprocs_start
         return supervisor_program_names(service_name, instance_count, instance_number_start, instance_name=instance_name)
-
-    def instance_number(self, instance_name):
-        try:
-            return int(instance_name) - self.config_numprocs_start
-        except (TypeError, ValueError) as exc:
-            gravity.io.exception(f"Invalid value for instance_name (must be an integer with supervisor): {exc}")
-
-    #@property
-    #def program_instances(self):
-    #    """ """
-    #    #instance_count = service_settings.get("instance_count", 1)
-    #    instance_number_start = self.service.settings.get("instance_number_start", 0)
-    #    return [(instance_number_start + i, name) for i, name in enumerate(self.program_names)]
-
 
 
 class SupervisorProcessManager(BaseProcessManager):
@@ -212,10 +193,6 @@ class SupervisorProcessManager(BaseProcessManager):
 
     def _service_environment_formatter(self, environment, format_vars):
         return ",".join("{}={}".format(k, shlex.quote(v.format(**format_vars))) for k, v in environment.items())
-
-    def service_instance_number(self, config, service, instance_name):
-        program = SupervisorProgram(config, service, self._use_instance_name)
-        return program.instance_number(instance_name)
 
     def terminate(self):
         if self.foreground:

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -291,7 +291,7 @@ class SupervisorProcessManager(BaseProcessManager):
             program_names.extend(program.program_names)
         return program_names
 
-    def __start_stop(self, op, configs, service_names):
+    def __op_on_programs(self, op, configs, service_names):
         targets = []
         for config in configs:
             if service_names:
@@ -324,11 +324,11 @@ class SupervisorProcessManager(BaseProcessManager):
 
     def start(self, configs=None, service_names=None):
         self.__supervisord()
-        self.__start_stop("start", configs, service_names)
+        self.__op_on_programs("start", configs, service_names)
         self.supervisorctl("status")
 
     def stop(self, configs=None, service_names=None):
-        self.__start_stop("stop", configs, service_names)
+        self.__op_on_programs("stop", configs, service_names)
         # Exit supervisor if all processes are stopped
         supervisor = self.__get_supervisor()
         if self.__supervisord_is_running():
@@ -344,7 +344,7 @@ class SupervisorProcessManager(BaseProcessManager):
             self.__supervisord()
             gravity.io.warn("supervisord was not previously running; it has been started, so the 'restart' command has been ignored")
         else:
-            self.__start_stop("restart", configs, service_names)
+            self.__op_on_programs("restart", configs, service_names)
 
     def graceful(self, configs=None, service_names=None):
         if not self.__supervisord_is_running():
@@ -357,7 +357,7 @@ class SupervisorProcessManager(BaseProcessManager):
         # TODO: create our own formatted output
         # supervisor = self.get_supervisor()
         # all_infos = supervisor.getAllProcessInfo()
-        self.supervisorctl("status")
+        self.__op_on_programs("status", configs, service_names)
 
     def shutdown(self):
         self.supervisorctl("shutdown")

--- a/gravity/process_manager/systemd.py
+++ b/gravity/process_manager/systemd.py
@@ -105,6 +105,9 @@ class SystemdProcessManager(BaseProcessManager):
     def _service_environment_formatter(self, environment, format_vars):
         return "\n".join("Environment={}={}".format(k, shlex.quote(v.format(**format_vars))) for k, v in environment.items())
 
+    def _service_name(self, instance_name, service):
+        return service["service_name"]
+
     def terminate(self):
         # this is used to stop a foreground supervisord in the supervisor PM, so it is a no-op here
         pass
@@ -161,7 +164,7 @@ class SystemdProcessManager(BaseProcessManager):
             if config.galaxy_group is not None:
                 systemd_format_vars["systemd_user_group"] += f"\nGroup={config.galaxy_group}"
 
-        format_vars = self._service_format_vars(config, service, program_name, systemd_format_vars)
+        format_vars = self._service_format_vars(config, service, systemd_format_vars)
 
         if not format_vars["command"].startswith("/"):
             format_vars["command"] = f"{format_vars['virtualenv_bin']}{format_vars['command']}"

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -173,6 +173,11 @@ Consumes less memory when multiple processes are configured. Default is ``false`
     umask: Optional[str] = Field(None, description="umask under which service should be executed")
     start_timeout: int = Field(15, description="Value of supervisor startsecs, systemd TimeoutStartSec")
     stop_timeout: int = Field(65, description="Value of supervisor stopwaitsecs, systemd TimeoutStopSec")
+    restart_timeout: int = Field(
+    300,
+    description="""
+Amount of time to wait for a server to become alive when performing rolling restarts.
+""")
     memory_limit: Optional[int] = Field(
         None,
         description="""

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -163,8 +163,8 @@ Consumes less memory when multiple processes are configured. Default is ``false`
     start_timeout: int = Field(15, description="Value of supervisor startsecs, systemd TimeoutStartSec")
     stop_timeout: int = Field(65, description="Value of supervisor stopwaitsecs, systemd TimeoutStopSec")
     restart_timeout: int = Field(
-    300,
-    description="""
+        default=300,
+        description="""
 Amount of time to wait for a server to become alive when performing rolling restarts.
 """)
     memory_limit: Optional[int] = Field(

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -180,14 +180,6 @@ Memory limit (in GB). If the service exceeds the limit, it will be killed. Defau
 Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
 names.
 """)
-    instance_name: Optional[Union[int, str]] = Field(
-        default=0,
-        description="""
-If the ``gunicorn`` section is a list, then mutliple gunicorns will be started. If set, this option controls the name of
-the "instance" of gunicorn. How this is represented depends on your process manager. In ``systemd``, most alphanumeric
-characters and a few special characters are valid. In ``supervisor`` only integers are valid, and only the first
-gunicorn's ``instance_name`` will be used (the other instances are incremented by 1).
-""")
 
 
 class ReportsSettings(BaseModel):
@@ -251,7 +243,8 @@ class GxItProxySettings(BaseModel):
         default="database/interactivetools_map.sqlite",
         description="""
 Routes file to monitor.
-Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section.
+Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section. This is ignored if
+``interactivetools_map is set``.
 """)
     verbose: bool = Field(default=True, description="Include verbose messages in gx-it-proxy")
     forward_ip: Optional[str] = Field(

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -234,8 +234,8 @@ class GalaxyGunicornService(Service):
         environment.update(self.settings.get("environment", {}))
         return environment
 
-    def is_ready(self, attribs, format_vars):
-        bind = self.get_command_arguments(attribs, format_vars)["bind"]
+    def is_ready(self, format_vars):
+        bind = self.get_command_arguments(format_vars)["bind"]
         gravity.io.debug(f"#### BIND! {bind}")
         http_check(bind, "/api/version")
         gravity.io.debug(f"#### CHECK OK! {bind}")

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -223,7 +223,7 @@ class ServiceList(BaseModel):
         gravity.io.info(f"Performing rolling restart on service: {self.service_name}")
         for instance_number, service_instance in enumerate(self.services):
             if not service_instance.is_ready(quiet=False):
-                gravity.io.exception(f"Refusing to continue rolling restart, instance {instance_number} was down before restart")
+                gravity.io.exception(f"Refusing to continue rolling restart, instance {instance_number} check failed before restart")
             gravity.io.debug(f"Calling restart callback {instance_number}: {restart_callbacks[instance_number]}")
             gravity.io.info(f"Restarting {self.service_name} instance {instance_number}")
             restart_callbacks[instance_number]()

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -127,7 +127,7 @@ class Service(BaseModel):
                     f"Settings for {cls._service_type} is a list, but lists are not allowed for this service type")
             for i, instance_settings in enumerate(settings):
                 services.extend(cls.services_if_enabled(config, settings=instance_settings, service_name=f"{service_name}{i}"))
-            if gravity_settings.service_command_style == ServiceCommandStyle.gravity:
+            if gravity_settings.use_service_instances:
                 services = [ServiceList(services=services, service_name=service_name)]
         elif isinstance(settings, dict) and settings[cls._enable_attribute]:
             # settings is already a dict e.g. in the case of handlers

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -225,12 +225,14 @@ class ServiceList(BaseModel):
             if not service_instance.is_ready(quiet=False):
                 gravity.io.exception(f"Refusing to continue rolling restart, instance {instance_number} was down before restart")
             gravity.io.debug(f"Calling restart callback {instance_number}: {restart_callbacks[instance_number]}")
+            gravity.io.info(f"Restarting {self.service_name} instance {instance_number}")
             restart_callbacks[instance_number]()
+            gravity.io.info(f"Restarted {self.service_name} instance {instance_number}, waiting for readiness check...")
             start = time.time()
             timeout = service_instance.settings["restart_timeout"]
             instance_is_ready = service_instance.is_ready()
             while not instance_is_ready and ((time.time() - start) < timeout):
-                gravity.io.debug(f"{program_name} not ready...")
+                gravity.io.debug(f"{self.service_name}@{instance_number} not ready...")
                 time.sleep(2)
                 instance_is_ready = service_instance.is_ready()
             if not instance_is_ready:
@@ -294,7 +296,7 @@ class GalaxyGunicornService(Service):
             return False
         live_version = f"{version['version_major']}.{version['version_minor']}"
         disk_version = self.config.galaxy_version
-        gravity.io.info(f"Gunicorn on {bind} running, version: {live_version} (disk version: {disk_version})")
+        gravity.io.info(f"Gunicorn on {bind} running, version: {live_version} (disk version: {disk_version})", bright=False)
         return True
 
 
@@ -483,7 +485,6 @@ SERVICE_CLASS_MAP = {
     "tusd": GalaxyTUSDService,
     "reports": GalaxyReportsService,
     "standalone": GalaxyStandaloneService,
-    #"_list_": ServiceList,
 }
 
 VALID_SERVICE_NAMES = set(SERVICE_CLASS_MAP)

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -4,9 +4,12 @@ import collections.abc
 import copy
 import os
 import sys
-import yaml
 
 import jsonref
+# FIXME: add to requirements
+import requests
+import yaml
+
 from gravity.settings import Settings
 
 
@@ -87,3 +90,13 @@ def process_property(key, value, depth=0):
             value_sep = " "
         description = f"{description}\n{extra_white_space}{comment}{key}:{value_sep}{default}\n"
     return description
+
+
+def http_check(bind, path):
+    scheme = 'http'
+    if bind.startswith('unix:'):
+        raise NotImplementedError("TODO: https://github.com/msabramo/requests-unixsocket")
+    try:
+        requests.get(f"{scheme}://{bind}{path}").raise_for_status()
+    except requests.exceptions.HTTPError:
+        raise

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -7,10 +7,7 @@ import sys
 
 import jsonref
 import requests
-try:
-    import requests_unixsocket
-except ImportError:
-    requests_unixsocket = None
+import requests_unixsocket
 import yaml
 
 import gravity.io
@@ -93,10 +90,6 @@ def process_property(key, value, depth=0):
 
 def http_check(bind, path):
     if bind.startswith("unix:"):
-        if not requests_unixsocket:
-            gravity.io.exception(
-                "The requests-unixsocket Python library is required to perform http checks on UNIX sockets, and it "
-                "does not appear to be installed")
         socket = requests.utils.quote(bind.split(":", 1)[1], safe="")
         session = requests_unixsocket.Session()
         response = session.get(f"http+unix://{socket}{path}")

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 import jsonref
-# FIXME: add to requirements
 import requests
 try:
     import requests_unixsocket

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -10,7 +10,6 @@ import requests
 import requests_unixsocket
 import yaml
 
-import gravity.io
 from gravity.settings import Settings
 
 

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -96,7 +96,6 @@ def http_check(bind, path):
     scheme = 'http'
     if bind.startswith('unix:'):
         raise NotImplementedError("TODO: https://github.com/msabramo/requests-unixsocket")
-    try:
-        requests.get(f"{scheme}://{bind}{path}").raise_for_status()
-    except requests.exceptions.HTTPError:
-        raise
+    response = requests.get(f"{scheme}://{bind}{path}", timeout=30)
+    response.raise_for_status()
+    return response

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -13,11 +13,6 @@ import yaml
 from gravity.settings import Settings
 
 
-class classproperty(property):
-    def __get__(self, cls, owner):
-        return classmethod(self.fget).__get__(None, owner)()
-
-
 def recursive_update(to_update, update_from):
     """
     Update values in `to_update` with values in `update_from`.

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,16 @@ setup(
     license="MIT",
     keywords="gravity galaxy",
     python_requires=">=3.6",
-    install_requires=["Click", "supervisor", "pyyaml", "packaging", "pydantic", "jsonref", "requests"],
-    extras_require={
-        "unixsocket": ["requests-unixsocket"],
-    },
+    install_requires=[
+        "Click",
+        "supervisor",
+        "pyyaml",
+        "packaging",
+        "pydantic",
+        "jsonref",
+        "requests",
+        "requests-unixsocket",
+    ],
     entry_points={"console_scripts": [
         "galaxy = gravity.cli:galaxy",
         "galaxyctl = gravity.cli:galaxyctl",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
     license="MIT",
     keywords="gravity galaxy",
     python_requires=">=3.6",
-    install_requires=["Click", "supervisor", "pyyaml", "packaging", "pydantic", "jsonref"],
+    install_requires=["Click", "supervisor", "pyyaml", "packaging", "pydantic", "jsonref", "requests"],
+    extras_require={
+        "unixsocket": ["requests-unixsocket"],
+    },
     entry_points={"console_scripts": [
         "galaxy = gravity.cli:galaxy",
         "galaxyctl = gravity.cli:galaxyctl",

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -358,7 +358,7 @@ def test_default_memory_limit(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'MemoryLimit=2G' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'MemoryLimit=2G' in handler0_config_path.open().read()
 
@@ -379,7 +379,7 @@ def test_service_memory_limit(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'MemoryLimit=4G' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'MemoryLimit' not in handler0_config_path.open().read()
 
@@ -401,7 +401,7 @@ def test_override_memory_limit(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'MemoryLimit=4G' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'MemoryLimit=2G' in handler0_config_path.open().read()
 
@@ -421,7 +421,7 @@ def test_default_umask(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'UMask=022' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'UMask=022' in handler0_config_path.open().read()
 
@@ -442,7 +442,7 @@ def test_service_umask(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'UMask=077' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'UMask=022' in handler0_config_path.open().read()
 
@@ -464,7 +464,7 @@ def test_override_umask(galaxy_yml, default_config_manager):
     conf_dir = service_conf_dir(state_dir, process_manager_name)
     gunicorn_conf_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'gunicorn')
     assert 'UMask=077' in gunicorn_conf_path.open().read()
-    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
+    handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'UMask=027' in handler0_config_path.open().read()
 

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from gravity import process_manager
+from gravity.process_manager.supervisor import supervisor_program_names
 from yaml import safe_load
 
 
@@ -466,6 +467,15 @@ def test_override_umask(galaxy_yml, default_config_manager):
     handler0_config_path = conf_dir / service_conf_file(instance_name, process_manager_name, 'handler_0', service_type='standalone')
     assert handler0_config_path.exists(), os.listdir(conf_dir)
     assert 'UMask=027' in handler0_config_path.open().read()
+
+
+def test_supervisor_program_names():
+    assert supervisor_program_names("gunicorn", 1, 0) == ["gunicorn"]
+    assert supervisor_program_names("gunicorn", 2, 0) == ["gunicorn:0", "gunicorn:1"]
+    assert supervisor_program_names("gunicorn", 2, 8080) == ["gunicorn:8080", "gunicorn:8081"]
+    assert supervisor_program_names("gunicorn", 1, 0, instance_name="main") == ["main:gunicorn"]
+    assert supervisor_program_names("gunicorn", 2, 0, instance_name="main") == ["main:gunicorn0", "main:gunicorn1"]
+    assert supervisor_program_names("gunicorn", 2, 8080, instance_name="main") == ["main:gunicorn8080", "main:gunicorn8081"]
 
 
 # TODO: test switching PMs in between invocations, test multiple instances


### PR DESCRIPTION
This should alleviate the need for unicornherder or gunicorn `SIGUSR2`-based solutions to zero downtime restarts. usegalaxy.eu is already using this in production, albeit without Gravity. This change allows Gravity to perform the restart using `galaxyctl graceful`.

I also changed repeating services (so, multiple gunicorns and multiple dynamic handlers under the same name in the Gravity config) to use service instances - `numprocs` in supervisord and `unit@.service` in systemd. This isn't strictly required but it's maybe a nice feature for keeping things organized.

Although one of the benefits you could get from service instances isn't possible: namely, if you have `N` handlers configured, you might imagine adding additional handlers with `systemctl start galaxy-handler@N+1.service`, but that doesn't work since the systemd service runs `galaxyctl exec -i N+1 handler` and `N+1` handlers must be configured in Gravity or else it'll throw an out of bounds error.

You can disable service instances with the new `use_service_instances` option or telling Gravity to write the actual command to the service unit instead of `galaxyctl exec ...` using `service_command_style: direct`. It's not really feasible to make direct service commands and service instances worth together since all you have to work with in a template service instance is the instance name template variable `%i`. As discussed on #63.

Fixes #74.