### PR TITLE
Hide the "exec" ServiceCommandStyle from documentation since it is only used internally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -437,7 +437,7 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
     # What command to write to the process manager configs
     # `gravity` (`galaxyctl exec <service-name>`) is the default
     # `direct` (each service's actual command) is also supported.
-    # Valid options are: gravity, direct, exec
+    # Valid options are: gravity, direct
     # service_command_style: gravity
 
     # Use the process manager's *service instance* functionality for services that can run multiple instances.

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -40,7 +40,7 @@ class ProcessManager(str, Enum):
 class ServiceCommandStyle(str, Enum):
     gravity = "gravity"
     direct = "direct"
-    exec = "exec"
+    exec = "_exec"
 
 
 class AppServer(str, Enum):

--- a/gravity/util/__init__.py
+++ b/gravity/util/__init__.py
@@ -69,7 +69,8 @@ def process_property(key, value, depth=0):
     has_child = False
     for item in allOff:
         if "enum" in item:
-            description = f'{description}\n{extra_white_space}# Valid options are: {", ".join(item["enum"])}'
+            enum_items = [i for i in item["enum"] if not i.startswith("_")]
+            description = f'{description}\n{extra_white_space}# Valid options are: {", ".join(enum_items)}'
         if "properties" in item:
             has_child = True
             for _key, _value in item["properties"].items():


### PR DESCRIPTION
As [discussed here](https://github.com/galaxyproject/galaxy/pull/15017#discussion_r1039892985)