### PR TITLE
Always add venv bin dir to `$PATH` if `virtualenv` is set

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -126,7 +126,7 @@ class Service(BaseModel):
     _service_list_allowed = False
 
     _graceful_method: GracefulMethod = GracefulMethod.DEFAULT
-    _add_virtualenv_to_path = False
+    _add_virtualenv_to_path = True
     _command_arguments: Dict[str, str] = {}
     _command_template: str = None
 


### PR DESCRIPTION
Related to #97, which fixed the case of in-job external set-metadata but not post-job subprocess (e.g. Pulsar if remote metadata is not enabled).