### PR TITLE
[1.x] Added configuration of gx-it-proxy to support path-based proxying

### DIFF
--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -26,6 +26,13 @@ DEFAULT_JOB_CONFIG_FILES = ("job_conf.yml", "job_conf.xml")
 if "XDG_CONFIG_HOME" in os.environ:
     DEFAULT_STATE_DIR = os.path.join(os.environ["XDG_CONFIG_HOME"], "galaxy-gravity")
 
+OPTIONAL_APP_KEYS = (
+    "interactivetools_map",
+    "interactivetools_base_path",
+    "interactivetools_prefix",
+    "galaxy_url_prefix",
+)
+
 
 @contextlib.contextmanager
 def config_manager(config_file=None, state_dir=None):
@@ -158,7 +165,7 @@ class ConfigManager(object):
         }
 
         # some things should only be included if set
-        for app_key in ("interactivetools_map", "galaxy_url_prefix"):
+        for app_key in OPTIONAL_APP_KEYS:
             if app_key in app_config:
                 app_config_dict[app_key] = app_config[app_key]
 

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -393,12 +393,19 @@ class GalaxyGxItProxyService(Service):
     _command_template = "{virtualenv_bin}npx gx-it-proxy --ip {settings[ip]} --port {settings[port]}" \
                         " --sessions {settings[sessions]} {command_arguments[verbose]}" \
                         " {command_arguments[forward_ip]} {command_arguments[forward_port]}" \
-                        " {command_arguments[reverse_proxy]}"
+                        " {command_arguments[reverse_proxy]} {command_arguments[proxy_path_prefix]}"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # override from Galaxy config if set
         self.settings["sessions"] = self.config.app_config.get("interactivetools_map", self.settings["sessions"])
+        # this can only be set in Galaxy config
+        it_base_path = self.config.app_config.get("interactivetools_base_path")
+        if it_base_path is not None:
+            it_prefix = app_config.get("interactivetools_prefix", "interactivetool")
+            self.settings["proxy_path_prefix"] = f"/{it_base_path.strip('/')}/{it_prefix}/access/interactivetoolentrypoint"
+        else:
+            self.settings["proxy_path_prefix"] = None
 
     @validator("settings")
     def _validate_settings(cls, v, values):

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -389,6 +389,7 @@ class GalaxyGxItProxyService(Service):
         "forward_ip": "--forwardIP {settings[forward_ip]}",
         "forward_port": "--forwardPort {settings[forward_port]}",
         "reverse_proxy": "--reverseProxy",
+        "proxy_path_prefix": "--proxyPathPrefix {settings[proxy_path_prefix]}",
     }
     _command_template = "{virtualenv_bin}npx gx-it-proxy --ip {settings[ip]} --port {settings[port]}" \
                         " --sessions {settings[sessions]} {command_arguments[verbose]}" \
@@ -402,8 +403,9 @@ class GalaxyGxItProxyService(Service):
         # this can only be set in Galaxy config
         it_base_path = self.config.app_config.get("interactivetools_base_path")
         if it_base_path is not None:
-            it_prefix = app_config.get("interactivetools_prefix", "interactivetool")
-            self.settings["proxy_path_prefix"] = f"/{it_base_path.strip('/')}/{it_prefix}/access/interactivetoolentrypoint"
+            it_base_path = "/" + f"/{it_base_path.strip('/')}/".lstrip("/")
+            it_prefix = self.config.app_config.get("interactivetools_prefix", "interactivetool")
+            self.settings["proxy_path_prefix"] = f"{it_base_path}{it_prefix}/access/interactivetoolentrypoint"
         else:
             self.settings["proxy_path_prefix"] = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,6 @@ galaxy:
   galaxy_infrastructure_url: http://localhost:{gx_port}
   interactivetools_upstream_proxy: false
   interactivetools_proxy_host: localhost:{gxit_port}
-  interactivetools_base_path: /
-  interactivetools_prefix: interactivetool
 """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ galaxy:
   galaxy_infrastructure_url: http://localhost:{gx_port}
   interactivetools_upstream_proxy: false
   interactivetools_proxy_host: localhost:{gxit_port}
+  interactivetools_base_path: /
+  interactivetools_prefix: interactivetool
 """
 
 

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -326,11 +326,25 @@ def test_gxit_handler(default_config_manager, galaxy_yml, gxit_config, process_m
         gxit_config_path = service_conf_path(state_dir, process_manager_name, 'gx-it-proxy')
         assert gxit_config_path.exists()
         gxit_port = gxit_config["gravity"]["gx_it_proxy"]["port"]
-        gxit_base_path = gxit_config["galaxy"]["interactivetools_base_path"]
-        gxit_prefix = gxit_config["galaxy"]["interactivetools_prefix"]
         sessions = "database/interactivetools_map.sqlite"
+        gxit_config_contents = gxit_config_path.read_text()
+        assert f'npx gx-it-proxy --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
+        assert '--proxyPathPrefix' not in gxit_config_contents
+
+
+@pytest.mark.parametrize('process_manager_name', ['supervisor', 'systemd'])
+def test_gxit_handler_path_prefix(default_config_manager, galaxy_yml, gxit_config, process_manager_name):
+    state_dir = default_config_manager.state_dir
+    gxit_base_path = gxit_config["galaxy"]["interactivetools_base_path"] = "/foo/"
+    gxit_prefix = gxit_config["galaxy"]["interactivetools_prefix"] = "bar"
+    galaxy_yml.write(json.dumps(gxit_config))
+    default_config_manager.load_config_file(str(galaxy_yml))
+    with process_manager.process_manager(config_manager=default_config_manager) as pm:
+        pm.update()
+        gxit_config_path = service_conf_path(state_dir, process_manager_name, 'gx-it-proxy')
+        assert gxit_config_path.exists()
         proxy_path_prefix = f'{gxit_base_path}{gxit_prefix}/access/interactivetoolentrypoint'
-        assert f'npx gx-it-proxy --ip localhost --port {gxit_port} --sessions {sessions} --proxyPathPrefix {proxy_path_prefix}' in gxit_config_path.read_text()
+        assert f'--proxyPathPrefix {proxy_path_prefix}' in gxit_config_path.read_text()
 
 
 @pytest.mark.parametrize('process_manager_name', ['supervisor', 'systemd'])

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -326,8 +326,11 @@ def test_gxit_handler(default_config_manager, galaxy_yml, gxit_config, process_m
         gxit_config_path = service_conf_path(state_dir, process_manager_name, 'gx-it-proxy')
         assert gxit_config_path.exists()
         gxit_port = gxit_config["gravity"]["gx_it_proxy"]["port"]
+        gxit_base_path = gxit_config["galaxy"]["interactivetools_base_path"]
+        gxit_prefix = gxit_config["galaxy"]["interactivetools_prefix"]
         sessions = "database/interactivetools_map.sqlite"
-        assert f'npx gx-it-proxy --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_path.read_text()
+        proxy_path_prefix = f'{gxit_base_path}{gxit_prefix}/access/interactivetoolentrypoint'
+        assert f'npx gx-it-proxy --ip localhost --port {gxit_port} --sessions {sessions} --proxyPathPrefix {proxy_path_prefix}' in gxit_config_path.read_text()
 
 
 @pytest.mark.parametrize('process_manager_name', ['supervisor', 'systemd'])


### PR DESCRIPTION
Supersedes the 0.x-based #96.

Only adds `--proxyPathPrefix` if the Galaxy config option is set, which by my reading of https://github.com/galaxyproject/gx-it-proxy/pull/14 should be valid, but correct me if I'm wrong @sveinugu.