### PR TITLE
Pin a minimum package version of gx-it-proxy

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -276,6 +276,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # Set to true to start gx-it-proxy
       # enable: false
 
+      # gx-it-proxy version
+      # version: '>=0.0.5'
+
       # Public-facing IP of the proxy
       # ip: localhost
 

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -10,6 +10,7 @@ from typing import (
 from pydantic import BaseModel, BaseSettings, Extra, Field, validator
 
 DEFAULT_INSTANCE_NAME = "_default_"
+GX_IT_PROXY_MIN_VERSION = "0.0.5"
 
 
 def none_to_default(cls, v, field):
@@ -237,6 +238,7 @@ names.
 
 class GxItProxySettings(BaseModel):
     enable: bool = Field(default=False, description="Set to true to start gx-it-proxy")
+    version: str = Field(default=f">={GX_IT_PROXY_MIN_VERSION}", description="gx-it-proxy version")
     ip: str = Field(default="localhost", description="Public-facing IP of the proxy")
     port: int = Field(default=4002, description="Public-facing port of the proxy")
     sessions: str = Field(

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -391,7 +391,7 @@ class GalaxyGxItProxyService(Service):
         "reverse_proxy": "--reverseProxy",
         "proxy_path_prefix": "--proxyPathPrefix {settings[proxy_path_prefix]}",
     }
-    _command_template = "{virtualenv_bin}npx gx-it-proxy --ip {settings[ip]} --port {settings[port]}" \
+    _command_template = "{virtualenv_bin}npx gx-it-proxy@{settings[version]} --ip {settings[ip]} --port {settings[port]}" \
                         " --sessions {settings[sessions]} {command_arguments[verbose]}" \
                         " {command_arguments[forward_ip]} {command_arguments[forward_port]}" \
                         " {command_arguments[reverse_proxy]} {command_arguments[proxy_path_prefix]}"

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from gravity import process_manager
 from gravity.process_manager.supervisor import supervisor_program_names
+from gravity.settings import GX_IT_PROXY_MIN_VERSION
 from yaml import safe_load
 
 
@@ -328,7 +329,7 @@ def test_gxit_handler(default_config_manager, galaxy_yml, gxit_config, process_m
         gxit_port = gxit_config["gravity"]["gx_it_proxy"]["port"]
         sessions = "database/interactivetools_map.sqlite"
         gxit_config_contents = gxit_config_path.read_text()
-        assert f'npx gx-it-proxy --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
+        assert f'npx gx-it-proxy@>={GX_IT_PROXY_MIN_VERSION} --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
         assert '--proxyPathPrefix /interactivetool/access/interactivetoolentrypoint' in gxit_config_contents
 
 


### PR DESCRIPTION
As @sveinugu pointed out in #96, not forcing the version to update will cause startup failures on existing Galaxy servers since older versions of the proxy do not have the new `--proxyPathPrefix` flag.