### PR TITLE
Set ownership of Gravity state dir to `galaxy_user:galaxy_group` when created by `SupervisorProcessManager`

### DIFF
--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -2,6 +2,7 @@
 """
 import os
 import shlex
+import shutil
 import subprocess
 import time
 from functools import partial
@@ -162,6 +163,13 @@ class SupervisorProcessManager(BaseProcessManager):
         self.foreground = foreground
 
         if not os.path.exists(self.supervisord_conf_dir):
+            if not os.path.exists(state_dir):
+                os.makedirs(state_dir)
+                shutil.chown(
+                    state_dir,
+                    self.config_manager.get_config().galaxy_user,
+                    self.config_manager.get_config().galaxy_group,
+                )
             os.makedirs(self.supervisord_conf_dir)
 
     @property


### PR DESCRIPTION
SupervisorProcessManager invokes `os.makedirs(self.supervisord_conf_dir)`, where `self.supervisord_conf_dir = os.path.join(self.supervisor_state_dir, "supervisord.conf.d")` and `self.supervisor_state_dir = os.path.join(state_dir, "supervisor")` and `state_dir` is the Gravity state directory. If `state_dir` does not exist beforehand and `galaxyctl` is invoked as root, then `state_dir` is created and owned by root, breaking Celery, as it needs to create the file celery-beat-schedule in `state_dir`, but runs as `galaxy_user`.

This the cause of [issue #187 in the ansible-galaxy repo](https://github.com/galaxyproject/ansible-galaxy/issues/187) and this PR attempts to fix it.