### PR TITLE
Minimal path change needed for galaxy PR 16795

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -277,7 +277,7 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # enable: false
 
       # gx-it-proxy version
-      # version: '>=0.0.5'
+      # version: '>=0.0.6'
 
       # Public-facing IP of the proxy
       # ip: localhost

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -10,7 +10,7 @@ from typing import (
 from pydantic import BaseModel, BaseSettings, Extra, Field, validator
 
 DEFAULT_INSTANCE_NAME = "_default_"
-GX_IT_PROXY_MIN_VERSION = "0.0.5"
+GX_IT_PROXY_MIN_VERSION = "0.0.6"
 
 
 def none_to_default(cls, v, field):

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -404,7 +404,7 @@ class GalaxyGxItProxyService(Service):
         it_base_path = self.config.app_config.get("interactivetools_base_path", "/")
         it_base_path = "/" + f"/{it_base_path.strip('/')}/".lstrip("/")
         it_prefix = self.config.app_config.get("interactivetools_prefix", "interactivetool")
-        self.settings["proxy_path_prefix"] = f"{it_base_path}{it_prefix}/access/interactivetoolentrypoint"
+        self.settings["proxy_path_prefix"] = f"{it_base_path}{it_prefix}/ep"
 
     @validator("settings")
     def _validate_settings(cls, v, values):

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -330,7 +330,7 @@ def test_gxit_handler(default_config_manager, galaxy_yml, gxit_config, process_m
         sessions = "database/interactivetools_map.sqlite"
         gxit_config_contents = gxit_config_path.read_text()
         assert f'npx gx-it-proxy@>={GX_IT_PROXY_MIN_VERSION} --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
-        assert '--proxyPathPrefix /interactivetool/access/interactivetoolentrypoint' in gxit_config_contents
+        assert '--proxyPathPrefix /interactivetool/ep' in gxit_config_contents
 
 
 @pytest.mark.parametrize('process_manager_name', ['supervisor', 'systemd'])
@@ -344,7 +344,7 @@ def test_gxit_handler_path_prefix(default_config_manager, galaxy_yml, gxit_confi
         pm.update()
         gxit_config_path = service_conf_path(state_dir, process_manager_name, 'gx-it-proxy')
         assert gxit_config_path.exists()
-        proxy_path_prefix = f'{gxit_base_path}{gxit_prefix}/access/interactivetoolentrypoint'
+        proxy_path_prefix = f'{gxit_base_path}{gxit_prefix}/ep'
         assert f'--proxyPathPrefix {proxy_path_prefix}' in gxit_config_path.read_text()
 
 


### PR DESCRIPTION
Also requires new version 0.0.6 of gx-it-proxy (galaxyproject/gx-it-proxy#17).

Should result in a new release 1.0.4 after merge (as required by galaxyproject/galaxy#16795). @natefoo?

Replaces https://github.com/elixir-oslo/gravity/pull/2 which was within my own repo and just stupid! 😅