### PR TITLE
Fix GalaxyReportsService crash and remove config_type

### DIFF
--- a/gravity/commands/cmd_list.py
+++ b/gravity/commands/cmd_list.py
@@ -11,11 +11,11 @@ def cli(ctx, version):
 
     aliases: configs
     """
-    cols = ["{:<8}", "{:<18}", "{}"]
-    head = ["TYPE", "INSTANCE NAME", "CONFIG PATH"]
+    cols = ["{:<18}", "{}"]
+    head = ["INSTANCE NAME", "CONFIG PATH"]
     if version:
-        cols.insert(2, "{:<12}")
-        head.insert(2, "VERSION")
+        cols.insert(1, "{:<12}")
+        head.insert(1, "VERSION")
     cols_str = "  ".join(cols)
     with config_manager.config_manager(**ctx.parent.cm_kwargs) as cm:
         configs = cm.get_configs()
@@ -27,7 +27,7 @@ def cli(ctx, version):
                     config.gravity_config_file,
                 ]
                 if version:
-                    row.insert(2, config.galaxy_version)
+                    row.insert(1, config.galaxy_version)
                 click.echo(cols_str.format(*row))
         else:
             click.echo("No configured instances")

--- a/gravity/commands/cmd_list.py
+++ b/gravity/commands/cmd_list.py
@@ -23,7 +23,6 @@ def cli(ctx, version):
             click.echo(cols_str.format(*head))
             for config in configs:
                 row = [
-                    config.config_type,
                     config.instance_name,
                     config.gravity_config_file,
                 ]

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -170,7 +170,6 @@ class ConfigManager(object):
                 app_config_dict[app_key] = app_config[app_key]
 
         config = ConfigFile(
-            config_type=self.galaxy_server_config_section,
             app_config=app_config_dict,
             gravity_config_file=gravity_config_file,
             galaxy_config_file=galaxy_config_file,

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -77,7 +77,7 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
         return os.environ["PATH"]
 
     def _service_program_name(self, instance_name, service):
-        return f"{instance_name}_{service.config_type}_{service.service_type}_{service.service_name}"
+        return f"{instance_name}_{service.service_type}_{service.service_name}"
 
     def _service_format_vars(self, config, service, pm_format_vars=None):
         pm_format_vars = pm_format_vars or {}
@@ -85,7 +85,6 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
         virtualenv_bin = shlex.quote(f'{os.path.join(virtualenv_dir, "bin")}{os.path.sep}') if virtualenv_dir else ""
 
         format_vars = {
-            "config_type": service.config_type,
             "server_name": service.service_name,
             "galaxy_umask": service.settings.get("umask") or config.umask,
             "galaxy_conf": config.galaxy_config_file,

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -105,7 +105,7 @@ class SupervisorProgram:
     @property
     def config_file_name(self):
         service = self.service
-        return f"{service.config_type}_{service.service_type}_{service.service_name}.conf"
+        return f"{service.service_type}_{service.service_name}.conf"
 
     @property
     def config_program_name(self):
@@ -113,7 +113,7 @@ class SupervisorProgram:
         service = self.service
         if self._use_instance_name:
             instance_name = self.config.instance_name
-            return f"{instance_name}_{service.config_type}_{service.service_type}_{service.service_name}"
+            return f"{instance_name}_{service.service_type}_{service.service_name}"
         else:
             return service.service_name
 
@@ -284,7 +284,7 @@ class SupervisorProcessManager(BaseProcessManager):
         programs = []
         for service in config.services:
             self.__update_service(config, service, instance_conf_dir, instance_name, force)
-            programs.append(f"{instance_name}_{service.config_type}_{service.service_type}_{service.service_name}")
+            programs.append(f"{instance_name}_{service.service_type}_{service.service_name}")
 
         group_conf = os.path.join(self.supervisord_conf_dir, f"group_{instance_name}.conf")
         if self._use_instance_name:

--- a/gravity/process_manager/systemd.py
+++ b/gravity/process_manager/systemd.py
@@ -82,8 +82,8 @@ class SystemdService:
         else:
             description_process = ""
 
-        self.unit_prefix = f"{prefix_instance_name}-{service.service_name}"
-        self.description = f"{description_instance_name}{service.service_name}{description_process}"
+        self.unit_prefix = f"galaxy{prefix_instance_name}-{service.service_name}"
+        self.description = f"Galaxy{description_instance_name}{service.service_name}{description_process}"
 
     @property
     def unit_file_name(self):
@@ -161,7 +161,7 @@ class SystemdProcessManager(BaseProcessManager):
 
     def __target_unit_name(self, config):
         instance_name = f"-{config.instance_name}" if self._use_instance_name else ""
-        return f"{instance_name}.target"
+        return f"galaxy{instance_name}.target"
 
     def __unit_files_to_active_unit_names(self, unit_files):
         unit_names = []
@@ -205,7 +205,7 @@ class SystemdProcessManager(BaseProcessManager):
     def _present_pm_files_for_config(self, config):
         unit_files = set()
         instance_name = f"-{config.instance_name}" if self._use_instance_name else ""
-        target = os.path.join(self.__systemd_unit_dir, f"{instance_name}.target")
+        target = os.path.join(self.__systemd_unit_dir, f"galaxy{instance_name}.target")
         if os.path.exists(target):
             target_hash = self.__read_gravity_config_hash_from_target(target)
             if target_hash == config.path_hash:
@@ -283,11 +283,11 @@ class SystemdProcessManager(BaseProcessManager):
         target_conf = os.path.join(self.__systemd_unit_dir, target_unit_name)
         format_vars = {
             "gravity_config_hash": config.path_hash,
-            "systemd_description": "Galaxy processes",
+            "systemd_description": "Galaxy",
             "systemd_target_wants": " ".join(service_units),
         }
         if self._use_instance_name:
-            format_vars["systemd_description"] = f"{config.instance_name}"
+            format_vars["systemd_description"] += f" {config.instance_name}"
         contents = SYSTEMD_TARGET_TEMPLATE.format(**format_vars)
         if self._update_file(target_conf, contents, target_unit_name, "systemd unit", force):
             self.__systemctl("enable", target_conf)
@@ -378,7 +378,7 @@ class SystemdProcessManager(BaseProcessManager):
         """ """
         if self._use_instance_name:
             configs = self.config_manager.get_configs(process_manager=self.name)
-            self.__systemctl("stop", *[f"{c.instance_name}.target" for c in configs])
+            self.__systemctl("stop", *[f"galaxy-{c.instance_name}.target" for c in configs])
         else:
             self.__systemctl("stop", "galaxy.target")
 

--- a/gravity/process_manager/systemd.py
+++ b/gravity/process_manager/systemd.py
@@ -82,8 +82,8 @@ class SystemdService:
         else:
             description_process = ""
 
-        self.unit_prefix = f"{service.config_type}{prefix_instance_name}-{service.service_name}"
-        self.description = f"{config.config_type.capitalize()}{description_instance_name} {service.service_name}{description_process}"
+        self.unit_prefix = f"{prefix_instance_name}-{service.service_name}"
+        self.description = f"{description_instance_name}{service.service_name}{description_process}"
 
     @property
     def unit_file_name(self):
@@ -161,7 +161,7 @@ class SystemdProcessManager(BaseProcessManager):
 
     def __target_unit_name(self, config):
         instance_name = f"-{config.instance_name}" if self._use_instance_name else ""
-        return f"{config.config_type}{instance_name}.target"
+        return f"{instance_name}.target"
 
     def __unit_files_to_active_unit_names(self, unit_files):
         unit_names = []
@@ -205,7 +205,7 @@ class SystemdProcessManager(BaseProcessManager):
     def _present_pm_files_for_config(self, config):
         unit_files = set()
         instance_name = f"-{config.instance_name}" if self._use_instance_name else ""
-        target = os.path.join(self.__systemd_unit_dir, f"{config.config_type}{instance_name}.target")
+        target = os.path.join(self.__systemd_unit_dir, f"{instance_name}.target")
         if os.path.exists(target):
             target_hash = self.__read_gravity_config_hash_from_target(target)
             if target_hash == config.path_hash:
@@ -283,11 +283,11 @@ class SystemdProcessManager(BaseProcessManager):
         target_conf = os.path.join(self.__systemd_unit_dir, target_unit_name)
         format_vars = {
             "gravity_config_hash": config.path_hash,
-            "systemd_description": config.config_type.capitalize(),
+            "systemd_description": "Galaxy processes",
             "systemd_target_wants": " ".join(service_units),
         }
         if self._use_instance_name:
-            format_vars["systemd_description"] += f" {config.instance_name}"
+            format_vars["systemd_description"] = f"{config.instance_name}"
         contents = SYSTEMD_TARGET_TEMPLATE.format(**format_vars)
         if self._update_file(target_conf, contents, target_unit_name, "systemd unit", force):
             self.__systemctl("enable", target_conf)
@@ -378,7 +378,7 @@ class SystemdProcessManager(BaseProcessManager):
         """ """
         if self._use_instance_name:
             configs = self.config_manager.get_configs(process_manager=self.name)
-            self.__systemctl("stop", *[f"{c.config_type}-{c.instance_name}.target" for c in configs])
+            self.__systemctl("stop", *[f"{c.instance_name}.target" for c in configs])
         else:
             self.__systemctl("stop", "galaxy.target")
 

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -40,7 +40,6 @@ class GracefulMethod(str, enum.Enum):
 
 
 class ConfigFile(BaseModel):
-    config_type: str
     app_config: Dict[str, Any]
     gravity_config_file: str
     galaxy_config_file: str
@@ -116,8 +115,6 @@ class Service(BaseModel):
 
     settings: Dict[str, Any]
 
-    config_type: str = None
-
     _default_environment: Dict[str, str] = {}
 
     _settings_from: Optional[str] = None
@@ -151,9 +148,11 @@ class Service(BaseModel):
         return services
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.config_type = self.config.config_type
-
+        try:
+            super().__init__(*args, **kwargs)
+         except Exception as ex:
+            gravity.io.exception("{0} init failurre: {1}".format(type(self),ex))
+             
     @property
     def service_type(self):
         return self._service_type
@@ -191,7 +190,7 @@ class Service(BaseModel):
         return self._command_template
 
     def __eq__(self, other):
-        return self.config_type == other.config_type and self.service_type == other.service_type and self.service_name == other.service_name
+        return self.service_type == other.service_type and self.service_name == other.service_name
 
     def get_command_arguments(self, format_vars):
         """Convert settings into their command line arguments."""

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -150,9 +150,9 @@ class Service(BaseModel):
     def __init__(self, *args, **kwargs):
         try:
             super().__init__(*args, **kwargs)
-        except Exception as ex:
-            gravity.io.exception("{0} init failed: {1}".format(type(self),ex))
-             
+        except Exception as exc:
+            gravity.io.exception(f"{type(self)} init failed: {exc}")
+
     @property
     def service_type(self):
         return self._service_type
@@ -448,20 +448,21 @@ class GalaxyReportsService(Service):
                         " --config python:galaxy.web_stack.gunicorn_config" \
                         " {command_arguments[url_prefix]}" \
                         " {settings[extra_args]}"
-    
-    def  _ensure_config_absolute_path(cls,v,values):
+
+    def _ensure_config_absolute_path(cls, v, values):
         if "config_file" not in v:
             gravity.io.exception("No reports config files specified.")
         if not os.path.isabs(v["config_file"]):
-            v["config_file"] = os.path.join(os.path.dirname(values["config"].galaxy_config_file),v["config_file"])
+            v["config_file"] = os.path.join(os.path.dirname(values["config"].galaxy_config_file), v["config_file"])
         return None
 
     @validator("settings")
     def _validate_settings(cls, v, values):
-        GalaxyReportsService._ensure_config_absolute_path(cls,v,values)
+        GalaxyReportsService._ensure_config_absolute_path(cls, v, values)
         if not os.path.exists(v["config_file"]):
-            gravity.io.exception("Reports enabled but reports config file does not exist: {0}".format(v["config_file"]))
+            gravity.io.exception(f"Reports enabled but reports config file does not exist: {v['config_file']}")
         return v
+
 
 class GalaxyStandaloneService(Service):
     _service_type = "standalone"

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -151,7 +151,7 @@ class Service(BaseModel):
         try:
             super().__init__(*args, **kwargs)
          except Exception as ex:
-            gravity.io.exception("{0} init failurre: {1}".format(type(self),ex))
+            gravity.io.exception("{0} init failed: {1}".format(type(self),ex))
              
     @property
     def service_type(self):

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -150,7 +150,7 @@ class Service(BaseModel):
     def __init__(self, *args, **kwargs):
         try:
             super().__init__(*args, **kwargs)
-         except Exception as ex:
+        except Exception as ex:
             gravity.io.exception("{0} init failed: {1}".format(type(self),ex))
              
     @property

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -12,7 +12,6 @@ def test_load_defaults(galaxy_yml, galaxy_root_dir, state_dir, default_config_ma
     default_config_manager.load_config_file(str(galaxy_yml))
     config = default_config_manager.get_config()
     default_settings = Settings()
-    assert config.config_type == 'galaxy'
     assert config.process_manager == 'supervisor'
     assert config.instance_name == default_settings.instance_name
     assert config.services != []

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -27,7 +27,7 @@ def log_for_service(state_dir, process_manager_name, start_time, service_name, i
     else:
         # could probably just glob here
         if instance_name is not None:
-            log_name = f"{instance_name}_galaxy_{service_name}_{service_name}.log"
+            log_name = f"{instance_name}_{service_name}_{service_name}.log"
         else:
             log_name = f"{service_name}.log"
         path = state_dir / "log" / log_name

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -217,7 +217,8 @@ def test_cmd_show(state_dir, galaxy_yml):
     result = runner.invoke(galaxyctl, ['--config-file', str(galaxy_yml), 'show'])
     assert result.exit_code == 0, result.output
     details = safe_load(result.output)
-    assert details['config_type'] == 'galaxy'
+    assert details['galaxy_config_file'] == str(galaxy_yml)
+    assert details['instance_name'] == '_default_'
 
 
 def test_cmd_list(state_dir, galaxy_yml):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -225,5 +225,5 @@ def test_cmd_list(state_dir, galaxy_yml):
     runner = CliRunner()
     result = runner.invoke(galaxyctl, ['--config-file', str(galaxy_yml), 'list'])
     assert result.exit_code == 0, result.output
-    assert result.output.startswith("TYPE")
+    assert result.output.startswith("INSTANCE NAME")
     assert str(galaxy_yml) in result.output

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -203,7 +203,7 @@ def test_cmd_restart_with_update(state_dir, galaxy_yml, startup_config, free_por
     assert result.exit_code == 0, result.output
     start_instance(state_dir, galaxy_yml, free_port)
     # change prefix
-    prefix = '/galaxypf/'
+    prefix = '/galaxypf'
     startup_config['galaxy']['galaxy_url_prefix'] = prefix
     galaxy_yml.write(json.dumps(startup_config))
     result = runner.invoke(galaxyctl, ['--config-file', str(galaxy_yml), 'restart'])

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -108,7 +108,7 @@ def service_conf_dir(state_dir, process_manager_name):
 def service_conf_file(instance_name, process_manager_name, service_name, service_type=None):
     service_type = service_type or service_name
     if process_manager_name == 'supervisor':
-        return f'galaxy_{service_type}_{service_name}.conf'
+        return f'{service_type}_{service_name}.conf'
     elif process_manager_name == 'systemd':
         return f'galaxy-{instance_name}-{service_name}.service'
     raise Exception(f"Invalid process manager name: {process_manager_name}")


### PR DESCRIPTION
Hello,

This fix #115.  

In addition it also make the _ConfigFile_ class more robust by catching exceptions in the constructor; they were ignored previously. 
Finally, it delete the _config_type_  in both _ConfigFile_ and _Service_ classes. Firstly because it wasn't copied properly  in the _Service_ class constructor (the error was silent due to the previous issue), secondly because it has no current use. 

I tested the supervisor configuration locally but not the systemd one.   