### PR TITLE
Support new Galaxy configuration setting `interactivetoolsproxy_map`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -285,9 +285,9 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # Public-facing port of the proxy
       # port: 4002
 
-      # Routes file to monitor.
-      # Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section. This is ignored if
-      # ``interactivetools_map is set``.
+      # Database to monitor.
+      # Should be set to the same value as ``interactivetools_map`` (or ``interactivetools_map_sqlalchemy``) in the ``galaxy:`` section. This is
+      # ignored if either ``interactivetools_map`` or ``interactivetools_map_sqlalchemy`` are set.
       # sessions: database/interactivetools_map.sqlite
 
       # Include verbose messages in gx-it-proxy

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -286,8 +286,8 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # port: 4002
 
       # Database to monitor.
-      # Should be set to the same value as ``interactivetools_map`` (or ``interactivetools_map_sqlalchemy``) in the ``galaxy:`` section. This is
-      # ignored if either ``interactivetools_map`` or ``interactivetools_map_sqlalchemy`` are set.
+      # Should be set to the same value as ``interactivetools_map`` (or ``interactivetoolsproxy_map``) in the ``galaxy:`` section. This is
+      # ignored if either ``interactivetools_map`` or ``interactivetoolsproxy_map`` are set.
       # sessions: database/interactivetools_map.sqlite
 
       # Include verbose messages in gx-it-proxy

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -245,8 +245,8 @@ class GxItProxySettings(BaseModel):
         default="database/interactivetools_map.sqlite",
         description="""
 Database to monitor.
-Should be set to the same value as ``interactivetools_map`` (or ``interactivetools_map_sqlalchemy``) in the ``galaxy:`` section. This is
-ignored if either ``interactivetools_map`` or ``interactivetools_map_sqlalchemy`` are set.
+Should be set to the same value as ``interactivetools_map`` (or ``interactivetoolsproxy_map``) in the ``galaxy:`` section. This is
+ignored if either ``interactivetools_map`` or ``interactivetoolsproxy_map`` are set.
 """)
     verbose: bool = Field(default=True, description="Include verbose messages in gx-it-proxy")
     forward_ip: Optional[str] = Field(

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -244,9 +244,9 @@ class GxItProxySettings(BaseModel):
     sessions: str = Field(
         default="database/interactivetools_map.sqlite",
         description="""
-Routes file to monitor.
-Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section. This is ignored if
-``interactivetools_map is set``.
+Database to monitor.
+Should be set to the same value as ``interactivetools_map`` (or ``interactivetools_map_sqlalchemy``) in the ``galaxy:`` section. This is
+ignored if either ``interactivetools_map`` or ``interactivetools_map_sqlalchemy`` are set.
 """)
     verbose: bool = Field(default=True, description="Include verbose messages in gx-it-proxy")
     forward_ip: Optional[str] = Field(

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -399,7 +399,10 @@ class GalaxyGxItProxyService(Service):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # override from Galaxy config if set
-        self.settings["sessions"] = self.config.app_config.get("interactivetools_map", self.settings["sessions"])
+        self.settings["sessions"] = (
+            self.config.app_config.get("interactivetools_map_sqlalchemy") or
+            self.config.app_config.get("interactivetools_map", self.settings["sessions"])
+        )
         # this can only be set in Galaxy config
         it_base_path = self.config.app_config.get("interactivetools_base_path", "/")
         it_base_path = "/" + f"/{it_base_path.strip('/')}/".lstrip("/")

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -400,7 +400,7 @@ class GalaxyGxItProxyService(Service):
         super().__init__(*args, **kwargs)
         # override from Galaxy config if set
         self.settings["sessions"] = (
-            self.config.app_config.get("interactivetools_map_sqlalchemy") or
+            self.config.app_config.get("interactivetoolsproxy_map") or
             self.config.app_config.get("interactivetools_map", self.settings["sessions"])
         )
         # this can only be set in Galaxy config


### PR DESCRIPTION
At the moment, the Gravity setting `sessions` is "overridden" with `interactivetools_map` if configured in the Galaxy settings.

A new Galaxy setting `interactivetoolsproxy_map` was added in galaxyproject/galaxy#18481 that overrides interactivetools_map` if defined. Gravity should do the same. This PR also documents the change.