### PR TITLE
Installable galaxy support

### DIFF
--- a/gravity/cli.py
+++ b/gravity/cli.py
@@ -65,14 +65,16 @@ class GravityCLI(click.MultiCommand):
 @options.debug_option()
 @options.config_file_option()
 @options.state_dir_option()
+@options.data_dir_option()
 @options.no_log_option()
 @click.pass_context
-def galaxy(ctx, debug, config_file, state_dir, quiet):
+def galaxy(ctx, debug, config_file, state_dir, data_dir, quiet):
     """Run Galaxy server in the foreground"""
     set_debug(debug)
     ctx.cm_kwargs = {
         "config_file": config_file,
         "state_dir": state_dir,
+        "data_dir": data_dir,
     }
     mod = __import__("gravity.commands.cmd_start", None, None, ["cli"])
     return ctx.invoke(mod.cli, foreground=True, quiet=quiet)
@@ -83,13 +85,15 @@ def galaxy(ctx, debug, config_file, state_dir, quiet):
 @options.debug_option()
 @options.config_file_option()
 @options.state_dir_option()
+@options.data_dir_option()
 @options.user_mode_option()
 @click.pass_context
-def galaxyctl(ctx, debug, config_file, state_dir, user):
+def galaxyctl(ctx, debug, config_file, state_dir, data_dir, user):
     """Manage Galaxy server configurations and processes."""
     set_debug(debug)
     ctx.cm_kwargs = {
         "config_file": config_file,
         "state_dir": state_dir,
+        "data_dir": data_dir,
         "user_mode": user,
     }

--- a/gravity/options.py
+++ b/gravity/options.py
@@ -13,6 +13,12 @@ def state_dir_option():
     )
 
 
+def data_dir_option():
+    return click.option(
+        "--data-dir", type=click.Path(file_okay=False, writable=True, resolve_path=True), help="Directory where application data will be stored."
+    )
+
+
 def config_file_option():
     return click.option(
         "-c",

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -297,7 +297,6 @@ class ProcessExecutor(BaseProcessExecutionEnvironment):
         gravity.io.info(f"Executing: {print_env} {format_vars['command']}")
 
         if not no_exec:
-            os.chdir(cwd)
             os.execvpe(cmd[0], cmd, env)
 
 

--- a/gravity/process_manager/supervisor.py
+++ b/gravity/process_manager/supervisor.py
@@ -47,7 +47,7 @@ SUPERVISORD_SERVICE_TEMPLATE = """;
 
 [program:{supervisor_program_name}]
 command         = {command}
-directory       = {galaxy_root}
+{directory_line}
 umask           = {galaxy_umask}
 autostart       = true
 autorestart     = true
@@ -262,6 +262,12 @@ class SupervisorProcessManager(BaseProcessManager):
             "supervisor_process_name": program.config_process_name,
             "supervisor_numprocs_start": program.config_numprocs_start,
         }
+
+        # Add directory line only if needed
+        if service.needs_working_directory():
+            supervisor_format_vars["directory_line"] = f"directory       = {config.galaxy_root}"
+        else:
+            supervisor_format_vars["directory_line"] = ""
 
         format_vars = self._service_format_vars(config, service, supervisor_format_vars)
 

--- a/gravity/process_manager/systemd.py
+++ b/gravity/process_manager/systemd.py
@@ -28,7 +28,7 @@ PartOf={systemd_target}
 UMask={galaxy_umask}
 Type=simple
 {systemd_user_group}
-WorkingDirectory={galaxy_root}
+{working_directory}
 TimeoutStartSec={settings[start_timeout]}
 TimeoutStopSec={settings[stop_timeout]}
 ExecStart={command}
@@ -250,6 +250,8 @@ class SystemdProcessManager(BaseProcessManager):
         if service.graceful_method == GracefulMethod.SIGHUP:
             exec_reload = "ExecReload=/bin/kill -HUP $MAINPID"
 
+        # Check if working directory needs to be set
+
         # systemd-specific format vars
         systemd_format_vars = {
             "virtualenv_bin": shlex.quote(f'{os.path.join(virtualenv_dir, "bin")}{os.path.sep}'),
@@ -259,6 +261,7 @@ class SystemdProcessManager(BaseProcessManager):
             "systemd_memory_limit": memory_limit or "",
             "systemd_description": systemd_service.description,
             "systemd_target": self.__target_unit_name(config),
+            "working_directory": f"WorkingDirectory={config.galaxy_root}" if service.needs_working_directory() else "",
         }
         if not self.user_mode:
             systemd_format_vars["systemd_user_group"] = f"User={config.galaxy_user}"

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -89,8 +89,8 @@ class ConfigFile(BaseModel):
                 return os.path.abspath(os.path.join(os.path.dirname(galaxy_config_file), os.pardir))
             if galaxy_config_file.endswith(os.path.join("galaxy", "config", "sample", "galaxy.yml.sample")):
                 return os.path.abspath(os.path.join(os.path.dirname(galaxy_config_file), os.pardir, os.pardir, os.pardir, os.pardir))
-            if galaxy_spec := importlib.util.find_spec("galaxy"):
-                return galaxy_spec.origin
+            if (galaxy_spec := importlib.util.find_spec("galaxy")) and galaxy_spec.origin:
+                return os.path.dirname(galaxy_spec.origin)
             gravity.io.exception(
                 "Cannot locate Galaxy root directory: set $GALAXY_ROOT_DIR, the Gravity `galaxy_root` option, or "
                 "`root' in the Galaxy config")

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -23,7 +23,7 @@ def test_load_defaults(galaxy_yml, galaxy_root_dir, state_dir, default_config_ma
     assert gunicorn_settings['workers'] == default_settings.gunicorn.workers
     assert gunicorn_settings['timeout'] == default_settings.gunicorn.timeout
     assert gunicorn_settings['extra_args'] == default_settings.gunicorn.extra_args
-    assert gunicorn_settings['preload'] is True
+    assert gunicorn_settings['preload'] is False
     celery_settings = config.get_service('celery').settings
     assert celery_settings == default_settings.celery.dict()
     with pytest.raises(IndexError):
@@ -92,6 +92,11 @@ def test_auto_load_root_dir(galaxy_root_dir, monkeypatch):
 
 
 def test_gunicorn_graceful_method_preload(galaxy_yml, default_config_manager):
+    # Using preload by default if we have more than 1 worker
+    galaxy_yml.write(json.dumps(
+        {'galaxy': None, 'gravity': {
+            'gunicorn': {'workers': 2}}}
+    ))
     default_config_manager.load_config_file(str(galaxy_yml))
     config = default_config_manager.get_config()
     graceful_method = config.get_service('gunicorn').graceful_method


### PR DESCRIPTION
A little harder to use without a published meta-package, which could bring in gravity, but right now you can get a working instance with
```
uv venv /tmp/venv
source /tmp/venv/bin/activate
uv pip install galaxy-web-apps gravity
echo "{}" > galaxy.yml
galaxy -c galaxy.yml --data-dir .
```

Ideally I'd like to make it:

```
uv run galaxy
```
and make the config file location and data-dir optional flags that default to the current working directory.

Since we don't run through all the common_startup.sh stuff this is pretty quick to boot, and a nice basis for planemo + installed galaxy (which again, should be a lot faster and more robust without the tons of hard to predict choices that run.sh makes).

TODO:
 - [] copy sample files if we don't have them
 - [] pull client if we don't have it
 - [] add client publishing to release script