### PR TITLE
Update interactive tool command to reflect new package namespace

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -389,7 +389,7 @@ class GalaxyGxItProxyService(Service):
         "reverse_proxy": "--reverseProxy",
         "proxy_path_prefix": "--proxyPathPrefix {settings[proxy_path_prefix]}",
     }
-    _command_template = "{virtualenv_bin}npx gx-it-proxy@{settings[version]} --ip {settings[ip]} --port {settings[port]}" \
+    _command_template = "{virtualenv_bin}npx @galaxyproject/gx-it-proxy@{settings[version]} --ip {settings[ip]} --port {settings[port]}" \
                         " --sessions {settings[sessions]} {command_arguments[verbose]}" \
                         " {command_arguments[forward_ip]} {command_arguments[forward_port]}" \
                         " {command_arguments[reverse_proxy]} {command_arguments[proxy_path_prefix]}"

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -329,7 +329,7 @@ def test_gxit_handler(default_config_manager, galaxy_yml, gxit_config, process_m
         gxit_port = gxit_config["gravity"]["gx_it_proxy"]["port"]
         sessions = "database/interactivetools_map.sqlite"
         gxit_config_contents = gxit_config_path.read_text()
-        assert f'npx gx-it-proxy@>={GX_IT_PROXY_MIN_VERSION} --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
+        assert f'npx @galaxyproject/gx-it-proxy@>={GX_IT_PROXY_MIN_VERSION} --ip localhost --port {gxit_port} --sessions {sessions}' in gxit_config_contents
         assert '--proxyPathPrefix /interactivetool/ep' in gxit_config_contents
 
 


### PR DESCRIPTION
Recently, the `gx-it-proxy` npm package has been moved to the `@galaxyproject` namespace, where v.0.2.2 is now [published](https://www.npmjs.com/package/@galaxyproject/gx-it-proxy).

However, Gravity still is configured to run `npx install gx-it-proxy` instead of `npx install @galaxyproject/gx-it-proxy`, which still [refers to the old version](https://www.npmjs.com/package/gx-it-proxy).

This PR updates the `npx` command.

For more context, see https://github.com/galaxyproject/gx-it-proxy/issues/25