### PR TITLE
Rootless processmanagerless mode

### DIFF
--- a/gravity/cli.py
+++ b/gravity/cli.py
@@ -67,8 +67,9 @@ class GravityCLI(click.MultiCommand):
 @options.config_file_option()
 @options.state_dir_option()
 @options.no_log_option()
+@options.single_user_option()
 @click.pass_context
-def galaxy(ctx, debug, config_file, state_dir, quiet):
+def galaxy(ctx, debug, config_file, state_dir, quiet, single_user):
     """Run Galaxy server in the foreground"""
     set_debug(debug)
     ctx.cm_kwargs = {
@@ -76,6 +77,9 @@ def galaxy(ctx, debug, config_file, state_dir, quiet):
         "state_dir": state_dir,
         "process_manager": ProcessManager.multiprocessing.value,
     }
+    if single_user:
+        os.environ["GALAXY_CONFIG_SINGLE_USER"] = single_user
+        os.environ["GALAXY_CONFIG_ADMIN_USERS"] = single_user
     mod = __import__("gravity.commands.cmd_start", None, None, ["cli"])
     return ctx.invoke(mod.cli, foreground=True, quiet=quiet)
 

--- a/gravity/cli.py
+++ b/gravity/cli.py
@@ -7,6 +7,7 @@ import click
 
 from gravity import io
 from gravity import options
+from gravity.settings import ProcessManager
 
 
 CONTEXT_SETTINGS = {
@@ -73,6 +74,7 @@ def galaxy(ctx, debug, config_file, state_dir, quiet):
     ctx.cm_kwargs = {
         "config_file": config_file,
         "state_dir": state_dir,
+        "process_manager": ProcessManager.multiprocessing.value,
     }
     mod = __import__("gravity.commands.cmd_start", None, None, ["cli"])
     return ctx.invoke(mod.cli, foreground=True, quiet=quiet)

--- a/gravity/config_manager.py
+++ b/gravity/config_manager.py
@@ -169,7 +169,8 @@ class ConfigManager(object):
         galaxy_root = gravity_settings.galaxy_root or app_config.get("root")
 
         # TODO: document that the default state_dir is data_dir/gravity and that setting state_dir overrides this
-        gravity_data_dir = self.state_dir or os.path.join(app_config.get("data_dir", "database"), "gravity")
+        default_data_dir = "data" if galaxy_installed else "database"
+        gravity_data_dir = self.state_dir or os.path.join(app_config.get("data_dir", default_data_dir), "gravity")
         log_dir = gravity_settings.log_dir or os.path.join(gravity_data_dir, "log")
 
         # TODO: this should use galaxy.util.properties.load_app_properties() so that env vars work

--- a/gravity/io.py
+++ b/gravity/io.py
@@ -34,7 +34,7 @@ def error(message, *args):
 def warn(message, *args):
     if args:
         message = message % args
-    click.echo(click.style(message, fg="red"), err=True)
+    click.echo(click.style(message, fg="yellow"), err=True)
 
 
 def exception(message):

--- a/gravity/options.py
+++ b/gravity/options.py
@@ -31,6 +31,15 @@ def user_mode_option():
     )
 
 
+def single_user_option():
+    return click.option(
+        "-s",
+        "--single-user",
+        default=None,
+        help="Run Galaxy in single user mode with the specified account email"
+    )
+
+
 def no_log_option():
     return click.option(
         '--quiet', is_flag=True, default=False, help="Only output supervisor logs, do not include process logs"

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -112,7 +112,9 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
                 path = environment.get("PATH", self._service_default_path())
                 environment["PATH"] = ":".join([virtualenv_bin, path])
         else:
-            config_file = shlex.quote(config.gravity_config_file)
+            config_file_option = ""
+            if config.gravity_config_file:
+                config_file_option = f" --config-file {shlex.quote(config.gravity_config_file)}"
             # is there a click way to do this?
             galaxyctl = sys.argv[0]
             if galaxyctl.endswith(f"{os.path.sep}galaxy"):
@@ -124,7 +126,7 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
             instance_number_opt = ""
             if service.count > 1:
                 instance_number_opt = f" --service-instance {pm_format_vars['instance_number']}"
-            format_vars["command"] = f"{galaxyctl} --config-file {config_file} exec{instance_number_opt} {config.instance_name} {service.service_name}"
+            format_vars["command"] = f"{galaxyctl}{config_file_option} exec{instance_number_opt} {config.instance_name} {service.service_name}"
             environment = {}
         format_vars["environment"] = self._service_environment_formatter(environment, format_vars)
 

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -275,7 +275,7 @@ class ProcessExecutor(BaseProcessExecutionEnvironment):
 
         cmd = shlex.split(format_vars["command"])
         env = {**dict(os.environ), **format_vars["environment"]}
-        cwd = format_vars["galaxy_root"]
+        cwd = format_vars["galaxy_root"] or os.getcwd()
 
         # ensure the data dir exists
         try:

--- a/gravity/process_manager/__init__.py
+++ b/gravity/process_manager/__init__.py
@@ -88,7 +88,8 @@ class BaseProcessExecutionEnvironment(metaclass=ABCMeta):
             "server_name": service.service_name,
             "galaxy_umask": service.settings.get("umask") or config.umask,
             "galaxy_conf": config.galaxy_config_file,
-            "galaxy_root": config.galaxy_root,
+            # TODO: this is used as the runtime directory, but it should probably be something else
+            "galaxy_root": config.galaxy_root or os.getcwd(),
             "virtualenv_bin": virtualenv_bin,
             "gravity_data_dir": shlex.quote(config.gravity_data_dir),
             "app_config": config.app_config,

--- a/gravity/process_manager/multiprocessing.py
+++ b/gravity/process_manager/multiprocessing.py
@@ -1,0 +1,63 @@
+"""
+"""
+import multiprocessing
+
+import gravity.io
+from gravity.process_manager import BaseProcessManager, ProcessExecutor
+from gravity.settings import ProcessManager
+
+
+class MultiprocessingProcessManager(BaseProcessManager):
+
+    name = ProcessManager.multiprocessing
+
+    def __init__(self, process_executor=None, **kwargs):
+        super().__init__(**kwargs)
+
+        assert process_executor is not None, f"Process executor is required for {self.__class__.__name__}"
+        self.process_executor = process_executor
+        self.processes = []
+
+    def follow(self, configs=None, service_names=None, quiet=False):
+        """ """
+
+    def start(self, configs=None, service_names=None):
+        for config in configs:
+            for service in config.services:
+                process = multiprocessing.Process(target=self.process_executor.exec, args=(config, service))
+                process.start()
+                self.processes.append(process)
+        for process in self.processes:
+            process.join()
+
+    def pm(self, *args, **kwargs):
+        """ """
+
+    def stop(self, configs=None, service_names=None):
+        """ """
+
+    def _present_pm_files_for_config(self, config):
+        """ """
+
+    def _disable_and_remove_pm_files(self, pm_files):
+        """ """
+
+    def restart(self, configs=None, service_names=None):
+        """ """
+
+    def graceful(self, configs=None, service_names=None):
+        """ """
+
+    def status(self, configs=None, service_names=None):
+        """ """
+
+    def terminate(self):
+        """ """
+
+    def shutdown(self):
+        """ """
+
+    def update(self, configs=None, force=False, clean=False):
+        """ """
+
+    _service_environment_formatter = ProcessExecutor._service_environment_formatter

--- a/gravity/process_manager/multiprocessing.py
+++ b/gravity/process_manager/multiprocessing.py
@@ -2,7 +2,6 @@
 """
 import multiprocessing
 
-import gravity.io
 from gravity.process_manager import BaseProcessManager, ProcessExecutor
 from gravity.settings import ProcessManager
 

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -34,6 +34,7 @@ class LogLevel(str, Enum):
 class ProcessManager(str, Enum):
     supervisor = "supervisor"
     systemd = "systemd"
+    multiprocessing = "multiprocessing"
 
 
 class ServiceCommandStyle(str, Enum):
@@ -296,12 +297,13 @@ class Settings(BaseSettings):
     ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
     """
 
-    process_manager: ProcessManager = Field(
+    process_manager: Optional[ProcessManager] = Field(
         None,
         description="""
 Process manager to use.
 ``supervisor`` is the default process manager when Gravity is invoked as a non-root user.
 ``systemd`` is the default when Gravity is invoked as root.
+``multiprocessing`` is the default when Gravity is invoked as the foreground shortcut ``galaxy`` instead of ``galaxyctl``
 """)
 
     service_command_style: ServiceCommandStyle = Field(
@@ -421,8 +423,8 @@ See https://docs.galaxyproject.org/en/latest/admin/scaling.html#dynamically-defi
         if v is None:
             if os.geteuid() == 0:
                 v = ProcessManager.systemd.value
-            else:
-                v = ProcessManager.supervisor.value
+            #else:
+            #    v = ProcessManager.supervisor.value
         return v
 
     # disable service instances unless command style is gravity

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -423,8 +423,6 @@ See https://docs.galaxyproject.org/en/latest/admin/scaling.html#dynamically-defi
         if v is None:
             if os.geteuid() == 0:
                 v = ProcessManager.systemd.value
-            #else:
-            #    v = ProcessManager.supervisor.value
         return v
 
     # disable service instances unless command style is gravity

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -47,8 +47,8 @@ class GracefulMethod(str, enum.Enum):
 
 class ConfigFile(BaseModel):
     app_config: Dict[str, Any]
-    gravity_config_file: str
-    galaxy_config_file: str
+    gravity_config_file: Optional[str]
+    galaxy_config_file: Optional[str]
     instance_name: str
     process_manager: ProcessManager
     service_command_style: ServiceCommandStyle
@@ -84,7 +84,7 @@ class ConfigFile(BaseModel):
     @validator("galaxy_root")
     def _galaxy_root_required(cls, v, values):
         if v is None:
-            galaxy_config_file = values["galaxy_config_file"]
+            galaxy_config_file = values.get("galaxy_config_file")
             if os.environ.get("GALAXY_ROOT_DIR"):
                 v = os.path.abspath(os.environ["GALAXY_ROOT_DIR"])
             elif galaxy_installed:

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -34,7 +34,8 @@ CELERY_BEAT_DB_FILENAME = "celery-beat-schedule"
 
 def relative_to_galaxy_root(cls, v, values):
     if not os.path.isabs(v):
-        v = os.path.abspath(os.path.join(values["galaxy_root"], v))
+        galaxy_root = values.get("galaxy_root") or os.getcwd()
+        v = os.path.abspath(os.path.join(galaxy_root, v))
     return v
 
 
@@ -88,8 +89,7 @@ class ConfigFile(BaseModel):
             if os.environ.get("GALAXY_ROOT_DIR"):
                 v = os.path.abspath(os.environ["GALAXY_ROOT_DIR"])
             elif galaxy_installed:
-                # FIXME: probably should be data_dir in config
-                v = os.getcwd()
+                v = None
             elif os.path.exists(os.path.join(os.path.dirname(galaxy_config_file), os.pardir, "lib", "galaxy")):
                 v = os.path.abspath(os.path.join(os.path.dirname(galaxy_config_file), os.pardir))
             elif galaxy_config_file.endswith(os.path.join("galaxy", "config", "sample", "galaxy.yml.sample")):


### PR DESCRIPTION
Once the galaxy metapackage is published w/ galaxy-web-client, this allows you to:

```console
$ pip install galaxy
$ galaxy
```

The addition of multiprocessing removes the need for any state and log file handling for the simplest case of just starting Galaxy in the foreground.