### PR TITLE
Remove support for deprecated unicornherder

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -4,9 +4,7 @@ Advanced Usage
 Zero-Downtime Restarts
 ----------------------
 
-Prior to Gravity 1.0, the preferred solution for performing zero-downtime restarts was `unicornherder`_. However, due to
-limitations in the unicornherder software, it does not always successfully perform zero-downtime restarts. Because of
-this, Gravity is now able to perform rolling restarts of gunicorn services if more than one gunicorn is configured.
+Gravity is able to perform rolling restarts of gunicorn services if more than one gunicorn is configured.
 
 To run multiple gunicorn processes, configure the ``gunicorn`` section of the Gravity configuration as a *list*. Each
 item in the list is a gunicorn configuration, and can have all of the same parameters as a single gunicorn
@@ -159,5 +157,3 @@ config to a unique name.
 Although it is strongly encouraged to use systemd for running multiple instances, it is possible to use supervisor.
 Please see the :ref:`Gravity State` section for important details on how and where Gravity stores the supervisor
 configuration and log files.
-
-.. _unicornherder: https://github.com/alphagov/unicornherder

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -169,9 +169,7 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
 
     # Select the application server.
     # ``gunicorn`` is the default application server.
-    # ``unicornherder`` is a production-oriented manager for (G)unicorn servers that automates zero-downtime Galaxy server restarts,
-    # similar to uWSGI Zerg Mode used in the past.
-    # Valid options are: gunicorn, unicornherder
+    # Valid options are: gunicorn
     # app_server: gunicorn
 
     # Override the default instance name.
@@ -202,8 +200,8 @@ The following options in the ``gravity`` section of ``galaxy.yml`` can be used t
       # extra_args:
 
       # Use Gunicorn's --preload option to fork workers after loading the Galaxy Application.
-      # Consumes less memory when multiple processes are configured. Default is ``false`` if using unicornherder, else ``true``.
-      # preload:
+      # Consumes less memory when multiple processes are configured.
+      # preload: true
 
       # umask under which service should be executed
       # umask:

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -34,10 +34,6 @@ If running with multiple gunicorns, a rolling restart is performed, where Gravit
 to respond to requests after restarting, and then moves to the next one. This process should be transparent to clients.
 See :ref:`Zero-Downtime Restarts` for configuration details.
 
-If running with `unicornherder`_, a new Galaxy application will be started and the old one shut down only once the new
-one is accepting connections. This should also be transparent to clients, but limitations in the unicornherder software
-may allow interruptions to occur.
-
 update
 ------
 
@@ -105,6 +101,5 @@ Thus, although ``exec`` is mostly an internal subcommand, developers and admins 
 order to quickly and easily start just a single service and view only that service's logs in the foreground.
 
 .. _gunicorn: https://gunicorn.org/
-.. _unicornherder: https://github.com/alphagov/unicornherder
 .. _supervisor: http://supervisord.org/
 .. _exec(3): https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html

--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -45,7 +45,6 @@ class ServiceCommandStyle(str, Enum):
 
 class AppServer(str, Enum):
     gunicorn = "gunicorn"
-    unicornherder = "unicornherder"
 
 
 class Pool(str, Enum):
@@ -162,10 +161,10 @@ If you disable the ``preload`` option workers need to have finished booting with
 """)
     extra_args: str = Field(default="", description="Extra arguments to pass to Gunicorn command line.")
     preload: Optional[bool] = Field(
-        default=None,
+        default=True,
         description="""
 Use Gunicorn's --preload option to fork workers after loading the Galaxy Application.
-Consumes less memory when multiple processes are configured. Default is ``false`` if using unicornherder, else ``true``.
+Consumes less memory when multiple processes are configured.
 """)
     umask: Optional[str] = Field(None, description="umask under which service should be executed")
     start_timeout: int = Field(15, description="Value of supervisor startsecs, systemd TimeoutStartSec")
@@ -375,8 +374,6 @@ the ``systemd`` process manager.
         description="""
 Select the application server.
 ``gunicorn`` is the default application server.
-``unicornherder`` is a production-oriented manager for (G)unicorn servers that automates zero-downtime Galaxy server restarts,
-similar to uWSGI Zerg Mode used in the past.
 """)
     instance_name: str = Field(default=DEFAULT_INSTANCE_NAME, description="""Override the default instance name.
 this is hidden from you when running a single instance.""")

--- a/gravity/state.py
+++ b/gravity/state.py
@@ -288,13 +288,6 @@ class GalaxyGunicornService(Service):
                         " {command_arguments[preload]}" \
                         " {settings[extra_args]}"
 
-    @validator("settings")
-    def _normalize_settings(cls, v, values):
-        # TODO: should be copy?
-        if v["preload"] is None:
-            v["preload"] = True
-        return v
-
     @property
     def graceful_method(self):
         if self.settings.get("preload"):
@@ -329,34 +322,6 @@ class GalaxyGunicornService(Service):
         disk_version = self.config.galaxy_version
         gravity.io.info(f"Gunicorn on {bind} running, version: {live_version} (disk version: {disk_version})", bright=False)
         return True
-
-
-class GalaxyUnicornHerderService(Service):
-    _service_type = "unicornherder"
-    service_name = "unicornherder"
-    _settings_from = "gunicorn"
-    _graceful_method = GracefulMethod.SIGHUP
-    _default_environment = DEFAULT_GALAXY_ENVIRONMENT
-    _command_template = "{virtualenv_bin}unicornherder --" \
-                        " 'galaxy.webapps.galaxy.fast_factory:factory()'" \
-                        " --timeout {settings[timeout]}" \
-                        " --pythonpath lib" \
-                        " -k galaxy.webapps.galaxy.workers.Worker" \
-                        " -b {settings[bind]}" \
-                        " --workers={settings[workers]}" \
-                        " --config python:galaxy.web_stack.gunicorn_config" \
-                        " {command_arguments[preload]}" \
-                        " {settings[extra_args]}"
-
-    @validator("settings")
-    def _normalize_settings(cls, v, values):
-        # TODO: should be copy?
-        if v["preload"] is None:
-            v["preload"] = False
-        return v
-
-    environment = GalaxyGunicornService.environment
-    command_arguments = GalaxyGunicornService.command_arguments
 
 
 class GalaxyCeleryService(Service):
@@ -535,7 +500,6 @@ def service_for_service_type(service_type):
 # TODO: better to pull this from __class__.service_type
 SERVICE_CLASS_MAP = {
     "gunicorn": GalaxyGunicornService,
-    "unicornherder": GalaxyUnicornHerderService,
     "celery": GalaxyCeleryService,
     "celery-beat": GalaxyCeleryBeatService,
     "gx-it-proxy": GalaxyGxItProxyService,

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -30,20 +30,6 @@ def test_load_defaults(galaxy_yml, galaxy_root_dir, state_dir, default_config_ma
         config.get_service('tusd')
 
 
-def test_preload_default(galaxy_yml, default_config_manager):
-    app_server = 'unicornherder'
-    galaxy_yml.write(json.dumps({
-        'galaxy': None,
-        'gravity': {
-            'app_server': app_server
-        }
-    }))
-    default_config_manager.load_config_file(str(galaxy_yml))
-    config = default_config_manager.get_config()
-    unicornherder_settings = config.get_service('unicornherder').settings
-    assert unicornherder_settings['preload'] is False
-
-
 def test_load_non_default(galaxy_yml, default_config_manager, non_default_config):
     if default_config_manager.instance_count == 0:
         galaxy_yml.write(json.dumps(non_default_config))


### PR DESCRIPTION
https://github.com/alphagov/unicornherder has been archived and the package has been completely removed from PyPI.

As a consequence, change the default of `preload` to True.