### PR TITLE
Modernize remaining pydantic v1 syntax to v2

### DIFF
--- a/gravity/settings.py
+++ b/gravity/settings.py
@@ -9,6 +9,7 @@ import jsonref
 import yaml
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     field_validator,
     ValidationInfo,
@@ -151,8 +152,7 @@ Extra environment variables and their values to set when running the service. A 
 names.
 """)] = {}
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class GunicornSettings(BaseModel):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -29,7 +29,7 @@ def test_load_defaults(galaxy_yml, galaxy_root_dir, state_dir, default_config_ma
     assert gunicorn_settings['extra_args'] == default_settings.gunicorn.extra_args
     assert gunicorn_settings['preload'] is True
     celery_settings = config.get_service('celery').settings
-    assert celery_settings == default_settings.celery.dict()
+    assert celery_settings == default_settings.celery.model_dump()
     with pytest.raises(IndexError):
         config.get_service('tusd')
 


### PR DESCRIPTION
## Summary
- Replace `class Config: use_enum_values = True` with `model_config = ConfigDict(use_enum_values=True)` in `CelerySettings`
- Replace `.dict()` with `.model_dump()` in `test_config_manager.py`

## Test plan
- [x] Existing test suite passes