### PR TITLE
Use scripts/galaxy-main for source-mode standalone start

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -505,7 +505,7 @@ class GalaxyStandaloneService(Service):
         "stop_timeout": 65,
     }
     _service_list_allowed = True
-    _source_command_template: ClassVar[str] = "{virtualenv_bin}python ./lib/galaxy/main.py -c {galaxy_conf}" \
+    _source_command_template: ClassVar[str] = "{virtualenv_bin}python ./scripts/galaxy-main -c {galaxy_conf}" \
         " --server-name={settings[server_name]}{command_arguments[attach_to_pool]}"
     _installed_command_template: ClassVar[str] = "{virtualenv_bin}galaxy-main -c {galaxy_conf}" \
         " --server-name={settings[server_name]}{command_arguments[attach_to_pool]}"


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/21977 converted lib/galaxy/main.py into the package lib/galaxy/main/, where __init__.py is now a symlink to scripts/galaxy-main. The old path no longer exists on dev, breaking gravity's source-mode standalone command.

scripts/galaxy-main is the same script and is present in all supported Galaxy branches (24.1, 25.0, master, dev), so no version dispatch is needed. The installed-mode galaxy-main console script entry point is unaffected.