### PR TITLE
Use default celery beat schedule filename

### DIFF
--- a/gravity/state.py
+++ b/gravity/state.py
@@ -49,7 +49,7 @@ DEFAULT_GALAXY_ENVIRONMENT = {
     "PYTHONPATH": "lib",
     "GALAXY_CONFIG_FILE": "{galaxy_conf}",
 }
-CELERY_BEAT_DB_FILENAME = "celery-beat-schedule"
+CELERY_BEAT_DB_FILENAME = "celerybeat-schedule"
 
 
 def relative_to_galaxy_root(cls, value: str, info: ValidationInfo) -> str:


### PR DESCRIPTION
See https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename

xref. https://github.com/galaxyproject/galaxy/pull/22574