### PR TITLE
Use trusted publishing to upload to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,37 +1,40 @@
 name: Publish gravity to PyPI
-on:
-  release:
-    types: [created]
-  push:
-    tags:
-      - '*'
+on: [push, pull_request]
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+  build_packages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v6
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install --upgrade twine wheel
-    - name: Create and check packages
-      run: |
-        python3 setup.py sdist bdist_wheel
-        twine check dist/*
-        ls -l dist
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-    - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'release' && github.event.action == 'created'
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.9
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade build twine
+      - name: Create and check sdist and wheel packages
+        run: |
+          python3 -m build
+          twine check dist/*
+          ls -l dist
+      - uses: actions/upload-artifact@v7
+        with:
+          name: packages
+          path: dist/
+  pypi-publish:
+    needs: [build_packages]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'galaxyproject'
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: packages
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Also:
- Build and check packages also for git pushes and PRs
- Cache pip dependencies
- Use `build` to create sdist and wheel packages